### PR TITLE
Python 3 transition

### DIFF
--- a/addon/globalPlugins/brailleExtender/__init__.py
+++ b/addon/globalPlugins/brailleExtender/__init__.py
@@ -21,7 +21,7 @@ import wx
 
 import addonHandler
 addonHandler.initTranslation()
-import settings
+from . import settings
 import api
 import appModuleHandler
 import braille
@@ -44,13 +44,13 @@ import tones
 import ui
 import versionInfo
 import virtualBuffers
-
-import configBE
+from . import configBE
 config.conf.spec["brailleExtender"] = configBE.getConfspec()
-import utils
-from updateCheck import *
-import patchs
+from . import utils
+from .updateCheck import *
+from . import patchs
 
+isPy3 = True if sys.version_info >= (3, 0) else False
 instanceGP = None
 lang = configBE.lang
 ATTRS = config.conf["brailleExtender"]["attributes"].copy().keys()
@@ -686,7 +686,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	@staticmethod
 	def showHourDate():
 		currentHourDate = time.strftime('%X %x (%a, %W/53, %b)', time.localtime())
-		return braille.handler.message(currentHourDate.decode('mbcs'))
+		if isPy3: return braille.handler.message(currentHourDate)
+		else: return braille.handler.message(currentHourDate.decode('mbcs'))
 
 	def script_autoScroll(self, gesture, sil=False):
 		if self.hourDatePlayed:
@@ -755,7 +756,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	script_toggleVolume.__doc__ = _("Mute or unmute sound")
 
 	def script_getHelp(s, g):
-		import addonDoc
+		from . import addonDoc
 		addonDoc.AddonDoc(s)
 	script_getHelp.__doc__ = _(
 		'Show the %s documentation') % configBE._addonName

--- a/addon/globalPlugins/brailleExtender/__init__.py
+++ b/addon/globalPlugins/brailleExtender/__init__.py
@@ -185,7 +185,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		if config.conf["brailleExtender"]["lastNVDAVersion"] != updateCheck.versionInfo.version:
 			config.conf["brailleExtender"]["lastNVDAVersion"] = updateCheck.versionInfo.version
 			checkingForced = True
-		delayChecking = 86400 if config.conf["brailleExtender"]["updateChannel"] != configBE.CHANNEL_stable else 604800
+		delayChecking = 86400 if isPy3 or config.conf["brailleExtender"]["updateChannel"] != configBE.CHANNEL_stable else 604800
 		if not globalVars.appArgs.secure and config.conf["brailleExtender"]["autoCheckUpdate"] and (checkingForced or (time.time() - config.conf["brailleExtender"]["lastCheckUpdate"]) > delayChecking):
 			checkUpdates(True)
 			config.conf["brailleExtender"]["lastCheckUpdate"] = time.time()

--- a/addon/globalPlugins/brailleExtender/addonDoc.py
+++ b/addon/globalPlugins/brailleExtender/addonDoc.py
@@ -8,11 +8,11 @@ import re
 import addonHandler
 addonHandler.initTranslation()
 import braille
-import configBE
+from . import configBE
 from collections import OrderedDict
 import cursorManager
 import globalCommands
-import utils
+from . import utils
 import ui
 
 instanceGP = None

--- a/addon/globalPlugins/brailleExtender/configBE.py
+++ b/addon/globalPlugins/brailleExtender/configBE.py
@@ -39,32 +39,36 @@ CHOICE_review = "review"
 CHOICE_focusAndReview = "focusAndReview"
 NOVIEWSAVED = chr(4)
 
-outputMessage = OrderedDict([
+dict_ = dict if isPy3 else OrderedDict
+
+outputMessage = dict_([
 	(CHOICE_none,             _("none")),
 	(CHOICE_braille,          _("braille only")),
 	(CHOICE_speech,           _("speech only")),
 	(CHOICE_speechAndBraille, _("both"))
 ])
 
-attributeChoices = OrderedDict([
+attributeChoices = dict_([
 	(CHOICE_none,   _("none")),
 	(CHOICE_dots78, _("dots 7 and 8")),
 	(CHOICE_dot7,   _("dot 7")),
 	(CHOICE_dot8,   _("dot 8"))
 ])
+attributeChoicesKeys = list(attributeChoices)
+attributeChoicesValues = list(attributeChoices.values())
 
-updateChannels = OrderedDict([
+updateChannels = dict_([
 	(CHANNEL_stable,  _("stable")),
-	(CHANNEL_testing, _("testing")),
 	(CHANNEL_dev,     _("development"))
 ])
 
-focusOrReviewChoices = OrderedDict([
+focusOrReviewChoices = dict_([
 	(CHOICE_none,           _("none")),
 	(CHOICE_focus,          _("focus mode")),
 	(CHOICE_review,         _("review mode")),
 	(CHOICE_focusAndReview, _("both"))
 ])
+
 curBD = braille.handler.display.name
 backupDisplaySize = braille.handler.displaySize
 backupRoleLabels = {}

--- a/addon/globalPlugins/brailleExtender/configBE.py
+++ b/addon/globalPlugins/brailleExtender/configBE.py
@@ -5,9 +5,8 @@
 
 from __future__ import unicode_literals
 import os
-from cStringIO import StringIO
+import sys
 import globalVars
-#from colors import RGB
 from collections import OrderedDict
 
 import addonHandler
@@ -21,6 +20,8 @@ else: from validate import Validator
 import inputCore
 import languageHandler
 from logHandler import log
+
+isPy3 = True if sys.version_info >= (3, 0) else False
 
 CHANNEL_stable = "stable"
 CHANNEL_testing = "testing"
@@ -77,7 +78,8 @@ outputTables = inputTables = None
 preTable = []
 postTable = []
 configDir = "%s/brailleExtender" % globalVars.appArgs.configPath
-baseDir = os.path.dirname(__file__).decode("mbcs")
+baseDir = os.path.dirname(__file__)
+if not isPy3: baseDir = baseDir.decode("mbcs")
 _addonDir = os.path.join(baseDir, "..", "..")
 _addonName = addonHandler.Addon(_addonDir).manifest["name"]
 _addonVersion = addonHandler.Addon(_addonDir).manifest["version"]
@@ -278,7 +280,7 @@ def loadConf():
 	confGen = (r"%s\%s\%s\profile.ini" % (profilesDir, curBD, config.conf["brailleExtender"]["profile_%s" % curBD]))
 	if (curBD != "noBraille" and os.path.exists(confGen)):
 		profileFileExists = True
-		confspec = config.ConfigObj(StringIO(""""""), encoding="UTF-8", list_values=False)
+		confspec = config.ConfigObj("", encoding="UTF-8", list_values=False)
 		iniProfile = config.ConfigObj(confGen, configspec=confspec, indent_type="\t", encoding="UTF-8")
 		result = iniProfile.validate(Validator())
 		if result is not True:
@@ -323,7 +325,7 @@ def initGestures():
 	if profileFileExists and gesturesBDPath() != '?':
 		log.debug('Main gestures map found')
 		confGen = gesturesBDPath()
-		confspec = config.ConfigObj(StringIO(""""""), encoding="UTF-8", list_values=False)
+		confspec = config.ConfigObj("", encoding="UTF-8", list_values=False)
 		iniGestures = config.ConfigObj(confGen, configspec=confspec, indent_type="\t", encoding="UTF-8")
 		result = iniGestures.validate(Validator())
 		if result is not True:

--- a/addon/globalPlugins/brailleExtender/patchs.py
+++ b/addon/globalPlugins/brailleExtender/patchs.py
@@ -7,6 +7,7 @@
 from __future__ import unicode_literals
 import os
 import sys
+isPy3 = True if sys.version_info >= (3, 0) else False
 import time
 import api
 import braille
@@ -19,6 +20,7 @@ import globalCommands
 import inputCore
 import keyboardHandler
 import louis
+if isPy3: import louisHelper
 import queueHandler
 import sayAllHandler
 import scriptHandler
@@ -29,9 +31,11 @@ import watchdog
 from logHandler import log
 import addonHandler
 
+
 addonHandler.initTranslation()
 from .utils import getCurrentChar, getTether
 instanceGP = None
+chr_ = chr if isPy3 else unichr
 
 SELECTION_SHAPE = lambda: braille.SELECTION_SHAPE
 errorTable = False
@@ -126,18 +130,28 @@ def update(self):
 	"""
 	try:
 		mode = louis.dotsIO
-		if config.conf["braille"]["expandAtCursor"] and self.cursorPos is not None:
-			mode |= louis.compbrlAtCursor
+		if config.conf["braille"]["expandAtCursor"] and self.cursorPos is not None: mode |= louis.compbrlAtCursor
 		try:
-			text = unicode(self.rawText).replace('\0', '')
-			braille, self.brailleToRawPos, self.rawToBraillePos, brailleCursorPos = louis.translate(getCurrentBrailleTables(),
-				text,
-				# liblouis mutates typeform if it is a list.
-				typeform=tuple(
-					self.rawTextTypeforms) if isinstance(
-					self.rawTextTypeforms,
-					list) else self.rawTextTypeforms,
-				mode=mode, cursorPos=self.cursorPos or 0)
+			if isPy3:
+				self.brailleCells, self.brailleToRawPos, self.rawToBraillePos, self.brailleCursorPos = louisHelper.translate(
+					getCurrentBrailleTables(),
+					self.rawText,
+					typeform=self.rawTextTypeforms,
+					mode=mode,
+					cursorPos=self.cursorPos
+				)
+			else:
+				text = unicode(self.rawText).replace('\0', '')
+				braille, self.brailleToRawPos, self.rawToBraillePos, brailleCursorPos = louis.translate(getCurrentBrailleTables(),
+					text,
+					# liblouis mutates typeform if it is a list.
+					typeform=tuple(
+						self.rawTextTypeforms) if isinstance(
+						self.rawTextTypeforms,
+						list) else self.rawTextTypeforms,
+					mode=mode,
+					cursorPos=self.cursorPos or 0
+				)
 		except BaseException as e:
 			log.error("Unable to translate with tables: %s\nDetails: %s" % (getCurrentBrailleTables(), e))
 			global errorTable
@@ -145,31 +159,32 @@ def update(self):
 			if instanceGP.BRFMode: instanceGP.BRFMode = False
 			instanceGP.errorMessage(_("An unexpected error was produced while using several braille tables. Using default settings to avoid other errors. More information in NVDA log. Thanks to report it."))
 			return
-		# liblouis gives us back a character string of cells, so convert it to a list of ints.
-		# For some reason, the highest bit is set, so only grab the lower 8
-		# bits.
-		self.brailleCells = [ord(cell) & 255 for cell in braille]
-		# #2466: HACK: liblouis incorrectly truncates trailing spaces from its output in some cases.
-		# Detect this and add the spaces to the end of the output.
-		if self.rawText and self.rawText[-1] == " ":
-			# rawToBraillePos isn't truncated, even though brailleCells is.
-			# Use this to figure out how long brailleCells should be and thus
-			# how many spaces to add.
-			correctCellsLen = self.rawToBraillePos[-1] + 1
-			currentCellsLen = len(self.brailleCells)
-			if correctCellsLen > currentCellsLen:
-				self.brailleCells.extend(
-					(0,) * (correctCellsLen - currentCellsLen))
-		if self.cursorPos is not None:
-			# HACK: The cursorPos returned by liblouis is notoriously buggy (#2947 among other issues).
-			# rawToBraillePos is usually accurate.
-			try:
-				brailleCursorPos = self.rawToBraillePos[self.cursorPos]
-			except IndexError:
-				pass
-		else:
-			brailleCursorPos = None
-		self.brailleCursorPos = brailleCursorPos
+		if not isPy3:
+			# liblouis gives us back a character string of cells, so convert it to a list of ints.
+			# For some reason, the highest bit is set, so only grab the lower 8
+			# bits.
+			self.brailleCells = [ord(cell) & 255 for cell in braille]
+			# #2466: HACK: liblouis incorrectly truncates trailing spaces from its output in some cases.
+			# Detect this and add the spaces to the end of the output.
+			if self.rawText and self.rawText[-1] == " ":
+				# rawToBraillePos isn't truncated, even though brailleCells is.
+				# Use this to figure out how long brailleCells should be and thus
+				# how many spaces to add.
+				correctCellsLen = self.rawToBraillePos[-1] + 1
+				currentCellsLen = len(self.brailleCells)
+				if correctCellsLen > currentCellsLen:
+					self.brailleCells.extend(
+						(0,) * (correctCellsLen - currentCellsLen))
+			if self.cursorPos is not None:
+				# HACK: The cursorPos returned by liblouis is notoriously buggy (#2947 among other issues).
+				# rawToBraillePos is usually accurate.
+				try:
+					brailleCursorPos = self.rawToBraillePos[self.cursorPos]
+				except IndexError:
+					pass
+			else:
+				brailleCursorPos = None
+			self.brailleCursorPos = brailleCursorPos
 		if self.selectionStart is not None and self.selectionEnd is not None:
 			try:
 				# Mark the selection.
@@ -178,9 +193,8 @@ def update(self):
 					self.brailleSelectionEnd = len(self.brailleCells)
 				else:
 					self.brailleSelectionEnd = self.rawToBraillePos[self.selectionEnd]
-				for pos in xrange(
-						self.brailleSelectionStart,
-						self.brailleSelectionEnd):
+				fn = range if isPy3 else xrange
+				for pos in fn(self.brailleSelectionStart, self.brailleSelectionEnd):
 					self.brailleCells[pos] |= SELECTION_SHAPE()
 			except IndexError: pass
 		else:
@@ -188,6 +202,7 @@ def update(self):
 				self.brailleCells = [(cell & 63) for cell in self.brailleCells]
 	except BaseException as e:
 		log.error("Error with update braille patch, disabling: %s" % e)
+		errorTable = True
 
 #: braille.TextInfoRegion.nextLine()
 def nextLine(self):
@@ -243,17 +258,17 @@ def executeGesture(self, gesture):
 
 		script = gesture.script
 		if "brailleDisplayDrivers" in str(type(gesture)):
-			if instanceGP.brailleKeyboardLocked and ((hasattr(script, "__func__") and script.__func__.func_name != "script_toggleLockBrailleKeyboard") or not hasattr(script, "__func__")): return
+			if instanceGP.brailleKeyboardLocked and ((hasattr(script, "__func__") and script.__func__.__name__ != "script_toggleLockBrailleKeyboard") or not hasattr(script, "__func__")): return
 			if not config.conf["brailleExtender"]['stopSpeechUnknown'] and gesture.script == None: stopSpeech = False
-			elif hasattr(script, "__func__") and (script.__func__.func_name in [
-			'script_braille_dots','script_braille_enter',
-			'script_volumePlus','script_volumeMinus','script_toggleVolume',
-			'script_hourDate',
-			'script_ctrl','script_alt','script_nvda','script_win',
-			'script_ctrlAlt','script_ctrlAltWin','script_ctrlAltWinShift','script_ctrlAltShift','script_ctrlWin','script_ctrlWinShift','script_ctrlShift','script_altWin','script_altWinShift','script_altShift','script_winShift']
+			elif hasattr(script, "__func__") and (script.__func__.__name__ in [
+			"script_braille_dots", "script_braille_enter",
+			"script_volumePlus", "script_volumeMinus", "script_toggleVolume",
+			"script_hourDate",
+			"script_ctrl", "script_alt", "script_nvda", "script_win",
+			"script_ctrlAlt", "script_ctrlAltWin", "script_ctrlAltWinShift", "script_ctrlAltShift","script_ctrlWin","script_ctrlWinShift","script_ctrlShift","script_altWin","script_altWinShift","script_altShift","script_winShift"]
 			or (
 				not config.conf["brailleExtender"]['stopSpeechScroll'] and
-			script.__func__.func_name in ['script_braille_scrollBack','script_braille_scrollForward'])):
+			script.__func__.__name__ in ["script_braille_scrollBack","script_braille_scrollForward"])):
 				stopSpeech = False
 			else: stopSpeech = True
 		else: stopSpeech = True
@@ -282,6 +297,7 @@ def executeGesture(self, gesture):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.pauseSpeech, speechEffect == gesture.SPEECHEFFECT_PAUSE)
 
 		if log.isEnabledFor(log.IO) and not gesture.isModifier:
+			self._lastInputTime = time.time()
 			log.io("Input: %s" % gesture.identifiers[0])
 
 		if self._captureFunc:
@@ -351,7 +367,7 @@ def _translate(self, endWord):
 		self.bufferText = u""
 	oldTextLen = len(self.bufferText)
 	pos = self.untranslatedStart + self.untranslatedCursorPos
-	data = u"".join([unichr(cell | brailleInput.LOUIS_DOTS_IO_START) for cell in self.bufferBraille[:pos]])
+	data = u"".join([chr_(cell | brailleInput.LOUIS_DOTS_IO_START) for cell in self.bufferBraille[:pos]])
 	mode = louis.dotsIO | louis.noUndefinedDots
 	if (not self.currentFocusIsTextObj or self.currentModifiers) and self._table.contracted:
 		mode |=  louis.partialTrans
@@ -415,13 +431,13 @@ configBE.loadPostTable()
 configBE.loadPreTable()
 
 # applying patches
-#braille.Region.update = update
+braille.Region.update = update
 braille.TextInfoRegion.previousLine = previousLine
 braille.TextInfoRegion.nextLine = nextLine
-#inputCore.InputManager.executeGesture = executeGesture
+inputCore.InputManager.executeGesture = executeGesture
 NoInputGestureAction = inputCore.NoInputGestureAction
-#brailleInput.BrailleInputHandler.emulateKey = emulateKey
-#brailleInput.BrailleInputHandler._translate = _translate
+brailleInput.BrailleInputHandler.emulateKey = emulateKey
+brailleInput.BrailleInputHandler._translate = _translate
 globalCommands.GlobalCommands.script_braille_routeTo = script_braille_routeTo
 louis._createTablesString = _createTablesString
 script_braille_routeTo.__doc__ = origFunc["script_braille_routeTo"].__doc__

--- a/addon/globalPlugins/brailleExtender/patchs.py
+++ b/addon/globalPlugins/brailleExtender/patchs.py
@@ -14,7 +14,7 @@ import brailleInput
 import brailleTables
 import controlTypes
 import config
-import configBE
+from . import configBE
 import globalCommands
 import inputCore
 import keyboardHandler
@@ -30,7 +30,7 @@ from logHandler import log
 import addonHandler
 
 addonHandler.initTranslation()
-from utils import getCurrentChar, getTether
+from .utils import getCurrentChar, getTether
 instanceGP = None
 
 SELECTION_SHAPE = lambda: braille.SELECTION_SHAPE
@@ -415,13 +415,13 @@ configBE.loadPostTable()
 configBE.loadPreTable()
 
 # applying patches
-braille.Region.update = update
+#braille.Region.update = update
 braille.TextInfoRegion.previousLine = previousLine
 braille.TextInfoRegion.nextLine = nextLine
-inputCore.InputManager.executeGesture = executeGesture
+#inputCore.InputManager.executeGesture = executeGesture
 NoInputGestureAction = inputCore.NoInputGestureAction
-brailleInput.BrailleInputHandler.emulateKey = emulateKey
-brailleInput.BrailleInputHandler._translate = _translate
+#brailleInput.BrailleInputHandler.emulateKey = emulateKey
+#brailleInput.BrailleInputHandler._translate = _translate
 globalCommands.GlobalCommands.script_braille_routeTo = script_braille_routeTo
 louis._createTablesString = _createTablesString
 script_braille_routeTo.__doc__ = origFunc["script_braille_routeTo"].__doc__

--- a/addon/globalPlugins/brailleExtender/settings.py
+++ b/addon/globalPlugins/brailleExtender/settings.py
@@ -97,15 +97,15 @@ class GeneralDlg(gui.settingsDialogs.SettingsDialog):
 		self.autoCheckUpdate.SetValue(config.conf["brailleExtender"]["autoCheckUpdate"])
 
 		# Translators: label of a dialog.
-		self.updateChannel = sHelper.addLabeledControl(_("Add-on update channel"), wx.Choice, choices=configBE.updateChannels.values())
+		self.updateChannel = sHelper.addLabeledControl(_("Add-on update channel"), wx.Choice, choices=list(configBE.updateChannels.values()))
 		if config.conf["brailleExtender"]["updateChannel"] in configBE.updateChannels.keys():
-			itemToSelect = configBE.updateChannels.keys().index(config.conf["brailleExtender"]["updateChannel"])
-		else: itemToSelect = config.conf["brailleExtender"]["updateChannel"].index(configBE.CHANNEL_stable)
+			itemToSelect = list(configBE.updateChannels.keys()).index(config.conf["brailleExtender"]["updateChannel"])
+		else: itemToSelect = list(config.conf["brailleExtender"]["updateChannel"]).index(configBE.CHANNEL_stable)
 		self.updateChannel.SetSelection(itemToSelect)
 
 		# Translators: label of a dialog.
-		self.speakScroll = sHelper.addLabeledControl(_("Say current line while scrolling in"), wx.Choice, choices=configBE.focusOrReviewChoices.values())
-		self.speakScroll.SetSelection(configBE.focusOrReviewChoices.keys().index(config.conf["brailleExtender"]["speakScroll"]))
+		self.speakScroll = sHelper.addLabeledControl(_("Say current line while scrolling in"), wx.Choice, choices=list(configBE.focusOrReviewChoices.values()))
+		self.speakScroll.SetSelection(list(configBE.focusOrReviewChoices.keys()).index(config.conf["brailleExtender"]["speakScroll"]))
 
 		# Translators: label of a dialog.
 		self.stopSpeechScroll = sHelper.addItem(wx.CheckBox(self, label=_("Speech interrupt when scrolling on same line")))
@@ -130,19 +130,19 @@ class GeneralDlg(gui.settingsDialogs.SettingsDialog):
 		self.reviewModeTerminal.SetValue(config.conf["brailleExtender"]["reviewModeTerminal"])
 
 		# Translators: label of a dialog.
-		self.volumeChangeFeedback = sHelper.addLabeledControl(_("Feedback for volume change in"), wx.Choice, choices=configBE.outputMessage.values())
+		self.volumeChangeFeedback = sHelper.addLabeledControl(_("Feedback for volume change in"), wx.Choice, choices=list(configBE.outputMessage.values()))
 		if config.conf["brailleExtender"]["volumeChangeFeedback"] in configBE.outputMessage:
-			itemToSelect = configBE.outputMessage.keys().index(config.conf["brailleExtender"]["volumeChangeFeedback"])
+			itemToSelect = list(configBE.outputMessage.keys()).index(config.conf["brailleExtender"]["volumeChangeFeedback"])
 		else:
-			itemToSelect = configBE.outputMessage.keys().index(configBE.CHOICE_braille)
+			itemToSelect = list(configBE.outputMessage.keys()).index(configBE.CHOICE_braille)
 		self.volumeChangeFeedback.SetSelection(itemToSelect)
 
 		# Translators: label of a dialog.
-		self.modifierKeysFeedback = sHelper.addLabeledControl(_("Feedback for modifier keys in"), wx.Choice, choices=configBE.outputMessage.values())
+		self.modifierKeysFeedback = sHelper.addLabeledControl(_("Feedback for modifier keys in"), wx.Choice, choices=list(configBE.outputMessage.values()))
 		if config.conf["brailleExtender"]["modifierKeysFeedback"] in configBE.outputMessage:
-			itemToSelect = configBE.outputMessage.keys().index(config.conf["brailleExtender"]["modifierKeysFeedback"])
+			itemToSelect = list(configBE.outputMessage.keys()).index(config.conf["brailleExtender"]["modifierKeysFeedback"])
 		else:
-			itemToSelect = configBE.outputMessage.keys().index(configBE.CHOICE_braille)
+			itemToSelect = list(configBE.outputMessage.keys()).index(configBE.CHOICE_braille)
 		# Translators: label of a dialog.
 		self.beepsModifiers = sHelper.addItem(wx.CheckBox(self, label=_("Play beeps for modifier keys")))
 		self.beepsModifiers.SetValue(config.conf["brailleExtender"]["beepsModifiers"])
@@ -181,8 +181,8 @@ class GeneralDlg(gui.settingsDialogs.SettingsDialog):
 		config.conf["brailleExtender"]["speakRoutingTo"] = self.speakRoutingTo.IsChecked()
 		config.conf["brailleExtender"]["routingReviewModeWithCursorKeys"] = self.routingReviewModeWithCursorKeys.IsChecked()
 
-		config.conf["brailleExtender"]["updateChannel"] = configBE.updateChannels.keys()[self.updateChannel.GetSelection()]
-		config.conf["brailleExtender"]["speakScroll"] = configBE.focusOrReviewChoices.keys()[self.speakScroll.GetSelection()]
+		config.conf["brailleExtender"]["updateChannel"] = list(configBE.updateChannels.keys())[self.updateChannel.GetSelection()]
+		config.conf["brailleExtender"]["speakScroll"] = list(configBE.focusOrReviewChoices.keys())[self.speakScroll.GetSelection()]
 
 		config.conf["brailleExtender"]["autoScrollDelay_%s" % configBE.curBD] = self.autoScrollDelay.Value
 		config.conf["brailleExtender"]["rightMarginCells_%s" % configBE.curBD] = self.rightMarginCells.Value
@@ -190,8 +190,8 @@ class GeneralDlg(gui.settingsDialogs.SettingsDialog):
 		config.conf["brailleExtender"]["brailleDisplay2"] = self.bds_k[self.brailleDisplay2.GetSelection()]
 		if configBE.gesturesFileExists:
 			config.conf["brailleExtender"]["keyboardLayout_%s" % configBE.curBD] = configBE.iniProfile["keyboardLayouts"].keys()[self.KBMode.GetSelection()]
-		config.conf["brailleExtender"]["volumeChangeFeedback"] = configBE.outputMessage.keys()[self.volumeChangeFeedback.GetSelection()]
-		config.conf["brailleExtender"]["modifierKeysFeedback"] = configBE.outputMessage.keys()[self.modifierKeysFeedback.GetSelection()]
+		config.conf["brailleExtender"]["volumeChangeFeedback"] = list(configBE.outputMessage.keys())[self.volumeChangeFeedback.GetSelection()]
+		config.conf["brailleExtender"]["modifierKeysFeedback"] = list(configBE.outputMessage.keys())[self.modifierKeysFeedback.GetSelection()]
 		config.conf["brailleExtender"]["beepsModifiers"] = self.beepsModifiers.IsChecked()
 		super(GeneralDlg, self).onOk(evt)
 
@@ -204,37 +204,37 @@ class AttribraDlg(gui.settingsDialogs.SettingsDialog):
 		sHelper = gui.guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		self.toggleAttribra = sHelper.addItem(wx.CheckBox(self, label=_("Enable Attribra")))
 		self.toggleAttribra.SetValue(config.conf["brailleExtender"]["features"]["attributes"])
-		self.spellingErrorsAttribute = sHelper.addLabeledControl(_("Show spelling errors with"), wx.Choice, choices=configBE.attributeChoices.values())
+		self.spellingErrorsAttribute = sHelper.addLabeledControl(_("Show spelling errors with"), wx.Choice, choices=configBE.attributeChoicesValues)
 		self.spellingErrorsAttribute.SetSelection(self.getItemToSelect("invalid-spelling"))
-		self.boldAttribute = sHelper.addLabeledControl(_("Show bold with"), wx.Choice, choices=configBE.attributeChoices.values())
+		self.boldAttribute = sHelper.addLabeledControl(_("Show bold with"), wx.Choice, choices=configBE.attributeChoicesValues)
 		self.boldAttribute.SetSelection(self.getItemToSelect("bold"))
-		self.italicAttribute = sHelper.addLabeledControl(_("Show italic with"), wx.Choice, choices=configBE.attributeChoices.values())
+		self.italicAttribute = sHelper.addLabeledControl(_("Show italic with"), wx.Choice, choices=configBE.attributeChoicesValues)
 		self.italicAttribute.SetSelection(self.getItemToSelect("italic"))
-		self.underlineAttribute = sHelper.addLabeledControl(_("Show underline with"), wx.Choice, choices=configBE.attributeChoices.values())
+		self.underlineAttribute = sHelper.addLabeledControl(_("Show underline with"), wx.Choice, choices=configBE.attributeChoicesValues)
 		self.underlineAttribute.SetSelection(self.getItemToSelect("underline"))
-		self.strikethroughAttribute = sHelper.addLabeledControl(_("Show strikethrough with"), wx.Choice, choices=configBE.attributeChoices.values())
+		self.strikethroughAttribute = sHelper.addLabeledControl(_("Show strikethrough with"), wx.Choice, choices=configBE.attributeChoicesValues)
 		self.strikethroughAttribute.SetSelection(self.getItemToSelect("strikethrough"))
-		self.subAttribute = sHelper.addLabeledControl(_("Show subscript with"), wx.Choice, choices=configBE.attributeChoices.values())
+		self.subAttribute = sHelper.addLabeledControl(_("Show subscript with"), wx.Choice, choices=configBE.attributeChoicesValues)
 		self.subAttribute.SetSelection(self.getItemToSelect("text-position:sub"))
-		self.superAttribute = sHelper.addLabeledControl(_("Show superscript with"), wx.Choice, choices=configBE.attributeChoices.values())
+		self.superAttribute = sHelper.addLabeledControl(_("Show superscript with"), wx.Choice, choices=configBE.attributeChoicesValues)
 		self.superAttribute.SetSelection(self.getItemToSelect("text-position:super"))
 
 	def postInit(self): self.toggleAttribra.SetFocus()
 
 	def onOk(self, evt):
 		config.conf["brailleExtender"]["features"]["attributes"] = self.toggleAttribra.IsChecked()
-		config.conf["brailleExtender"]["attributes"]["invalid-spelling"] = configBE.attributeChoices.keys()[self.spellingErrorsAttribute.GetSelection()]
-		config.conf["brailleExtender"]["attributes"]["bold"] = configBE.attributeChoices.keys()[self.boldAttribute.GetSelection()]
-		config.conf["brailleExtender"]["attributes"]["italic"] = configBE.attributeChoices.keys()[self.italicAttribute.GetSelection()]
-		config.conf["brailleExtender"]["attributes"]["underline"] = configBE.attributeChoices.keys()[self.underlineAttribute.GetSelection()]
-		config.conf["brailleExtender"]["attributes"]["strikethrough"] = configBE.attributeChoices.keys()[self.strikethroughAttribute.GetSelection()]
-		config.conf["brailleExtender"]["attributes"]["text-position:sub"] = configBE.attributeChoices.keys()[self.subAttribute.GetSelection()]
-		config.conf["brailleExtender"]["attributes"]["text-position:super"] = configBE.attributeChoices.keys()[self.superAttribute.GetSelection()]
+		config.conf["brailleExtender"]["attributes"]["invalid-spelling"] = configBE.attributeChoicesKeys[self.spellingErrorsAttribute.GetSelection()]
+		config.conf["brailleExtender"]["attributes"]["bold"] = configBE.attributeChoicesKeys[self.boldAttribute.GetSelection()]
+		config.conf["brailleExtender"]["attributes"]["italic"] = configBE.attributeChoicesKeys[self.italicAttribute.GetSelection()]
+		config.conf["brailleExtender"]["attributes"]["underline"] = configBE.attributeChoicesKeys[self.underlineAttribute.GetSelection()]
+		config.conf["brailleExtender"]["attributes"]["strikethrough"] = configBE.attributeChoicesKeys[self.strikethroughAttribute.GetSelection()]
+		config.conf["brailleExtender"]["attributes"]["text-position:sub"] = configBE.attributeChoicesKeys[self.subAttribute.GetSelection()]
+		config.conf["brailleExtender"]["attributes"]["text-position:super"] = configBE.attributeChoicesKeys[self.superAttribute.GetSelection()]
 		super(AttribraDlg, self).onOk(evt)
 
 	@staticmethod
 	def getItemToSelect(attribute):
-		try: idx = configBE.attributeChoices.keys().index(config.conf["brailleExtender"]["attributes"][attribute])
+		try: idx = configBE.attributeChoicesKeys.index(config.conf["brailleExtender"]["attributes"][attribute])
 		except BaseException as err:
 			log.error(err)
 			idx = 0
@@ -274,7 +274,7 @@ class RoleLabelsDlg(gui.settingsDialogs.SettingsDialog):
 		if idCategory == 0:
 			labels = [controlTypes.roleLabels[int(k)] for k in braille.roleLabels.keys()]
 		elif idCategory == 1:
-			labels = braille.landmarkLabels.keys()
+			labels = list(braille.landmarkLabels.keys())
 		elif idCategory == 2:
 			labels = [controlTypes.stateLabels[k] for k in braille.positiveStateLabels.keys()]
 		elif idCategory == 3:
@@ -307,7 +307,7 @@ class RoleLabelsDlg(gui.settingsDialogs.SettingsDialog):
 			if self.getOriginalLabel(idCategory, idLabel, chr(4)) == label:
 				if key in self.roleLabels.keys():
 					self.roleLabels.pop(key)
-					log.info("Key %s deleted" % key)
+					log.debug("Key %s deleted" % key)
 				else: log.info("Key %s not present" % key)
 			else: self.roleLabels[key] = label
 			actualLabel = self.getLabelFromID(idCategory, idLabel)
@@ -349,22 +349,19 @@ class RoleLabelsDlg(gui.settingsDialogs.SettingsDialog):
 	@staticmethod
 	def getIDFromIndexes(idCategory, idLabel):
 		try:
-			if idCategory == 0: return braille.roleLabels.keys()[idLabel]
-			elif idCategory == 1: return braille.landmarkLabels.keys()[idLabel]
-			elif idCategory == 2: return braille.positiveStateLabels.keys()[idLabel]
-			elif idCategory == 3: return braille.negativeStateLabels.keys()[idLabel]
-			else: return -1
+			if idCategory == 0: return list(braille.roleLabels.keys())[idLabel]
+			elif idCategory == 1: return list(braille.landmarkLabels.keys())[idLabel]
+			elif idCategory == 2: return list(braille.positiveStateLabels.keys())[idLabel]
+			elif idCategory == 3: return list(braille.negativeStateLabels.keys())[idLabel]
+			else: raise ValueError("Invalid value for ID category: %d" % idCategory)
 		except BaseException: return -1
 
 	def getLabelFromID(self, idCategory, idLabel):
-		if idCategory == 0:
-			return braille.roleLabels[idLabel]
-		elif idCategory == 1:
-			return braille.landmarkLabels[idLabel]
-		elif idCategory == 2:
-			return braille.positiveStateLabels[idLabel]
-		elif idCategory == 3:
-			return braille.negativeStateLabels[idLabel]
+		if idCategory == 0: return braille.roleLabels[idLabel]
+		elif idCategory == 1: return braille.landmarkLabels[idLabel]
+		elif idCategory == 2: return braille.positiveStateLabels[idLabel]
+		elif idCategory == 3: return braille.negativeStateLabels[idLabel]
+		else: raise ValueError("Invalid value: %d" % idCategory)
 
 	def postInit(self): self.toggleRoleLabels.SetFocus()
 
@@ -639,8 +636,8 @@ class QuickLaunchesDlg(gui.settingsDialogs.SettingsDialog):
 	captureLabelBtn = None
 
 	def makeSettings(self, settingsSizer):
-		self.quickLaunchGestures = config.conf["brailleExtender"]["quickLaunches"].copy().keys()
-		self.quickLaunchLocations = config.conf["brailleExtender"]["quickLaunches"].copy().values()
+		self.quickLaunchGestures = list(config.conf["brailleExtender"]["quickLaunches"].copy().keys())
+		self.quickLaunchLocations = list(config.conf["brailleExtender"]["quickLaunches"].copy().values())
 		sHelper = gui.guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		bHelper1 = gui.guiHelper.ButtonHelper(orientation=wx.HORIZONTAL)
 		self.quickKeys = sHelper.addLabeledControl(_("&Gestures"), wx.Choice, choices=self.getQuickLaunchList())
@@ -703,7 +700,8 @@ class QuickLaunchesDlg(gui.settingsDialogs.SettingsDialog):
 		inputCore.manager._captureFunc = getCaptured
 
 	def getQuickLaunchList(s):
-		return ['%s%s: %s' % (utils.beautifulSht(s.quickLaunchGestures[i]), configBE.sep, s.quickLaunchLocations[i]) for i, v in enumerate(s.quickLaunchLocations)]
+		quickLaunchGesturesKeys = list(s.quickLaunchGestures)
+		return ['%s%s: %s' % (utils.beautifulSht(quickLaunchGesturesKeys[i]), configBE.sep, v) for i, v in enumerate(s.quickLaunchLocations)]
 
 	def onRemoveGestureBtn(self, event):
 		if self.quickKeys.GetSelection() < 0:

--- a/addon/globalPlugins/brailleExtender/settings.py
+++ b/addon/globalPlugins/brailleExtender/settings.py
@@ -22,8 +22,8 @@ import scriptHandler
 import ui
 addonHandler.initTranslation()
 
-import configBE
-import utils
+from . import configBE
+from . import utils
 from logHandler import log
 
 instanceGP = None

--- a/addon/globalPlugins/brailleExtender/updateCheck.py
+++ b/addon/globalPlugins/brailleExtender/updateCheck.py
@@ -22,18 +22,20 @@ import core
 import config
 import globalVars
 import languageHandler
+import ui
 import versionInfo
 
 from . import configBE
 addonHandler.initTranslation()
 
 def paramsDL(): return {
-	"versionProtocole": "2.0",
+	"versionProtocole": "2.1",
 	"versionAddon": configBE._addonVersion,
 	"versionNVDA": versionInfo.version,
 	"language": languageHandler.getLanguage(),
 	"brailledisplay": braille.handler.display.name,
-	"channel": config.conf["brailleExtender"]["updateChannel"]
+	"channel": config.conf["brailleExtender"]["updateChannel"],
+	"py3": 1 if isPy3 else 0,
 }
 
 urlencode = urllib.parse.urlencode if isPy3 else urllib.urlencode

--- a/addon/globalPlugins/brailleExtender/updateCheck.py
+++ b/addon/globalPlugins/brailleExtender/updateCheck.py
@@ -6,8 +6,13 @@ from __future__ import unicode_literals
 from logHandler import log
 import json
 import os
+import sys
+isPy3 = True if sys.version_info >= (3, 0) else False
+if isPy3:
+	import urllib.parse
+	import urllib.request
+else: import urllib
 
-import urllib
 import gui
 import wx
 
@@ -19,7 +24,7 @@ import globalVars
 import languageHandler
 import versionInfo
 
-import configBE
+from . import configBE
 addonHandler.initTranslation()
 
 def paramsDL(): return {
@@ -30,6 +35,11 @@ def paramsDL(): return {
 	"brailledisplay": braille.handler.display.name,
 	"channel": config.conf["brailleExtender"]["updateChannel"]
 }
+
+urlencode = urllib.parse.urlencode if isPy3 else urllib.urlencode
+URLopener = urllib.request.URLopener if isPy3 else urllib.URLopener
+urlopen = urllib.request.urlopen if isPy3 else urllib.urlopen
+
 
 
 def checkUpdates(sil = False):
@@ -55,10 +65,10 @@ def checkUpdates(sil = False):
 		if res == wx.YES: os.startfile(configBE._addonURL)
 
 	def processUpdate():
-		url = configBE._addonURL + "latest?" + urllib.urlencode(paramsDL())
+		url = configBE._addonURL + "latest?" + urlencode(paramsDL())
 		fp = os.path.join(globalVars.appArgs.configPath, "brailleExtender.nvda-addon")
 		try:
-			dl = urllib.URLopener()
+			dl = URLopener()
 			dl.retrieve(url, fp)
 			try:
 				curAddons = []
@@ -84,9 +94,9 @@ def checkUpdates(sil = False):
 
 	title = _("BrailleExtender's Update")
 	newUpdate = False
-	url = '{0}BrailleExtender.latest?{1}'.format(configBE._addonURL, urllib.urlencode(paramsDL()))
+	url = '{0}BrailleExtender.latest?{1}'.format(configBE._addonURL, urlencode(paramsDL()))
 	try:
-		page = urllib.urlopen(url)
+		page = urlopen(url)
 		if page.code == 200:
 			data = json.load(page)
 			if not data["success"]: raise ValueError("Invalid JSON response")
@@ -96,7 +106,7 @@ def checkUpdates(sil = False):
 			if newUpdate: wx.CallAfter(availableUpdateDialog, data["lastVersion"], data["msg"])
 			else: wx.CallAfter(upToDateDialog, data["msg"])
 		else: raise ValueError("Invalid server code response: %s" % page.code)
-	except BaseException, err:
+	except BaseException as err:
 		log.warning(err)
 		if not newUpdate and sil: return
 		wx.CallAfter(errorUpdateDialog)

--- a/addon/globalPlugins/brailleExtender/utils.py
+++ b/addon/globalPlugins/brailleExtender/utils.py
@@ -22,6 +22,7 @@ from keyboardHandler import KeyboardInputGesture
 import addonHandler
 addonHandler.initTranslation()
 import treeInterceptorHandler
+import unicodedata
 
 isPy3 = True if sys.version_info >= (3, 0) else False
 charToDotsInLouis = hasattr(louis, "charToDots")
@@ -195,17 +196,15 @@ def reload_brailledisplay(bd_name):
 
 def currentCharDesc():
 	ch = getCurrentChar()
+	if not ch: return ui.message(_("Not a character"))
 	c = ord(ch)
-	if c != '':
-		s = '%c: %s; %s; %s; %s'% (ch, hex(c), c, oct(c), bin(c))
+	if c:
+		s = '%c: %s; %s; %s; %s; %s [%s]' % (ch, hex(c), c, oct(c), bin(c), unicodedata.name(ch), unicodedata.category(ch))
 		if scriptHandler.getLastScriptRepeatCount() == 0: ui.message(s)
-		elif (scriptHandler.getLastScriptRepeatCount() == 1):
+		elif scriptHandler.getLastScriptRepeatCount() == 1:
 			brch = getTextInBraille(ch)
-			ui.browseableMessage('%s\n%s (%s)' % (s, brch, unicodeBrailleToDescription(brch)), r'\x%d - Char info' % c)
-		else:
-			api.copyToClip(s)
-			ui.message('"{0}" copied to clipboard.'.format(s))
-	else: ui.message(_('Not a character.'))
+			ui.browseableMessage("%s\n%s (%s)" % (s, brch, unicodeBrailleToDescription(brch)), r'\x%d (%s) - Char info' % (c, ch))
+	else: ui.message(_("Not a character"))
 
 def getCurrentChar():
 	obj = api.getFocusObject()
@@ -217,8 +216,7 @@ def getCurrentChar():
 		info.expand(textInfos.UNIT_CHARACTER)
 		s = info.text
 		return s
-	except BaseException:
-		pass
+	except (TypeError, NotImplementedError): pass
 	return ''
 
 def getTextSelection():

--- a/addon/globalPlugins/brailleExtender/utils.py
+++ b/addon/globalPlugins/brailleExtender/utils.py
@@ -5,6 +5,7 @@
 
 from __future__ import unicode_literals
 import os.path as osp
+import sys
 import re
 import api
 import braille
@@ -22,8 +23,9 @@ import addonHandler
 addonHandler.initTranslation()
 import treeInterceptorHandler
 
+isPy3 = True if sys.version_info >= (3, 0) else False
 charToDotsInLouis = hasattr(louis, "charToDots")
-
+unichr_ = chr if isPy3 else unichr
 # -----------------------------------------------------------------------------
 # Thanks to Tim Roberts for the (next) Control Volume code!
 # -> https://mail.python.org/pipermail/python-win32/2014-March/013080.html
@@ -171,7 +173,7 @@ def getVolume():
 
 def bkToChar(dots, inTable=-1):
 	if inTable == -1: inTable = config.conf["braille"]["inputTable"]
-	char = unichr(dots | 0x8000)
+	char = unichr_(dots | 0x8000)
 	text = louis.backTranslate(
 		[osp.join(r"louis\tables", inTable),
 		 "braille-patterns.cti"],
@@ -260,13 +262,13 @@ def getTextInBraille(t = '', table = None):
 		nt.append(res)
 	nt = '\n'.join(nt)
 	if charToDotsInLouis: return nt
-	return ''.join([unichr(ord(ch)-0x8000+0x2800) if ord(ch) > 8000 else ch for ch in nt])
+	return ''.join([unichr_(ord(ch)-0x8000+0x2800) if ord(ch) > 8000 else ch for ch in nt])
 
 def cellDescToChar(cell):
 	if not re.match("^[0-8]+$", cell): return '?'
 	toAdd = 0
 	for dot in cell: toAdd += 1 << int(dot)-1 if int(dot) > 0 else 0
-	return unichr(10240+toAdd)
+	return unichr_(10240+toAdd)
 
 def charToCellDesc(ch):
 	"""
@@ -313,16 +315,16 @@ def getTableOverview(tbl = ''):
 	available = ""
 	i = 0x2800
 	while i<0x2800+256:
-		text = louis.backTranslate([osp.join(r"louis\tables", config.conf["braille"]["inputTable"]), "braille-patterns.cti"], unichr(i), mode=louis.ucBrl)
+		text = louis.backTranslate([osp.join(r"louis\tables", config.conf["braille"]["inputTable"]), "braille-patterns.cti"], unichr_(i), mode=louis.ucBrl)
 		if i != 0x2800:
 			t = 'Input              Output\n'
 		if not re.match(r'^\\.+/$', text[0]):
 			tmp['%s' % text[0] if text[0] != '' else '?'] = '%s       %-7s' % (
-			'%s (%s)' % (unichr(i), combinationDesign(unicodeBrailleToDescription(unichr(i)))),
+			'%s (%s)' % (unichr_(i), combinationDesign(unicodeBrailleToDescription(unichr_(i)))),
 			'%s%-8s' % (text[0], '%s' % (' (%-10s)' % str(hex(ord(text[0]))) if len(text[0]) == 1 else '' if text[0] != '' else '#ERROR'))
 			)
 		else:
-			available += unichr(i)
+			available += unichr_(i)
 		i += 1
 	t += '\n'.join(tmp[k] for k in sorted(tmp))
 	nbAvailable = len(available)

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BrailleExtender\n"
-"Report-Msgid-Bugs-To: nvda-translations@freelists.org\n"
-"POT-Creation-Date: 2019-02-18 11:58+0100\n"
-"PO-Revision-Date: 2019-02-18 12:17+0100\n"
+"Report-Msgid-Bugs-To: nvda-translations@groups.io\n"
+"POT-Creation-Date: 2019-08-16 12:30+0200\n"
+"PO-Revision-Date: 2019-08-16 12:31+0200\n"
 "Last-Translator: André-Abush CLAUSE <dev@andreabc.net>\n"
 "Language-Team: \n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.1.1\n"
+"X-Generator: Poedit 2.2.3\n"
 "X-Poedit-Basepath: ../../..\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -170,7 +170,7 @@ msgid "Opens the addon's documentation."
 msgstr "Ouvre la documentation du module complémentaire."
 
 #: addon\globalPlugins\brailleExtender\__init__.py:251
-#: addon\globalPlugins\brailleExtender\settings.py:42
+#: addon\globalPlugins\brailleExtender\settings.py:43
 msgid "&General"
 msgstr "&Général"
 
@@ -179,7 +179,7 @@ msgid "General configuration"
 msgstr "Configuration générale"
 
 #: addon\globalPlugins\brailleExtender\__init__.py:253
-#: addon\globalPlugins\brailleExtender\settings.py:44
+#: addon\globalPlugins\brailleExtender\settings.py:45
 msgid "Braille &tables"
 msgstr "&Tables braille"
 
@@ -188,7 +188,7 @@ msgid "Braille tables configuration"
 msgstr "Configuration des tables braille"
 
 #: addon\globalPlugins\brailleExtender\__init__.py:255
-#: addon\globalPlugins\brailleExtender\settings.py:46
+#: addon\globalPlugins\brailleExtender\settings.py:47
 msgid "Text &attributes"
 msgstr "&Attributs de texte"
 
@@ -197,7 +197,7 @@ msgid "Text attributes configuration"
 msgstr "Configuration des attributs de texte"
 
 #: addon\globalPlugins\brailleExtender\__init__.py:257
-#: addon\globalPlugins\brailleExtender\settings.py:48
+#: addon\globalPlugins\brailleExtender\settings.py:49
 msgid "&Quick launches"
 msgstr "&Lancements rapides"
 
@@ -206,7 +206,7 @@ msgid "Quick launches configuration"
 msgstr "Configuration des lancements rapides"
 
 #: addon\globalPlugins\brailleExtender\__init__.py:259
-#: addon\globalPlugins\brailleExtender\settings.py:50
+#: addon\globalPlugins\brailleExtender\settings.py:51
 msgid "Role &labels"
 msgstr "&Étiquettes de rôle"
 
@@ -215,7 +215,7 @@ msgid "Role labels configuration"
 msgstr "Configuration des étiquettes de rôle"
 
 #: addon\globalPlugins\brailleExtender\__init__.py:261
-#: addon\globalPlugins\brailleExtender\settings.py:52
+#: addon\globalPlugins\brailleExtender\settings.py:53
 msgid "&Profile editor"
 msgstr "Éditeur de &profils"
 
@@ -475,78 +475,78 @@ msgstr "Obtenir la position du curseur dans le texte"
 msgid "Hour and date with autorefresh"
 msgstr "Heure et date avec rafraîchissement automatique"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:697
+#: addon\globalPlugins\brailleExtender\__init__.py:698
 msgid "Autoscroll stopped"
 msgstr "Défilement automatique arrêté"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:704
+#: addon\globalPlugins\brailleExtender\__init__.py:705
 msgid "Unable to start autoscroll. More info in NVDA log"
 msgstr ""
 "Impossible de lancer le défilement automatique. Plus d’informations dans le "
 "journal NVDA"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:709
+#: addon\globalPlugins\brailleExtender\__init__.py:710
 msgid "Enable/disable autoscroll"
 msgstr "Activer / désactiver le défilement automatique"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:724
+#: addon\globalPlugins\brailleExtender\__init__.py:725
 msgid "Increase the master volume"
 msgstr "Augmenter le volume principal"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:741
+#: addon\globalPlugins\brailleExtender\__init__.py:742
 msgid "Decrease the master volume"
 msgstr "Diminuer le volume principal"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:747
+#: addon\globalPlugins\brailleExtender\__init__.py:748
 msgid "Muted sound"
 msgstr "Son coupé"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:749
+#: addon\globalPlugins\brailleExtender\__init__.py:750
 #, python-format
 msgid "Unmuted sound (%3d%%)"
 msgstr "Réactivé (%3d%%)"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:755
+#: addon\globalPlugins\brailleExtender\__init__.py:756
 msgid "Mute or unmute sound"
 msgstr "Couper ou rétablir le son"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:761
+#: addon\globalPlugins\brailleExtender\__init__.py:762
 #, python-format
 msgid "Show the %s documentation"
 msgstr "Afficher la documentation de %s"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:800
+#: addon\globalPlugins\brailleExtender\__init__.py:801
 msgid "No such file or directory"
 msgstr "Aucun fichier ou dossier de ce nom"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:802
+#: addon\globalPlugins\brailleExtender\__init__.py:803
 msgid "Opens a custom program/file. Go to settings to define them"
 msgstr ""
 "Ouvre un programme / fichier personnalisé. Accédez aux paramètres pour les "
 "définir"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:810
+#: addon\globalPlugins\brailleExtender\__init__.py:811
 #, python-format
 msgid "Check for %s updates, and starts the download if there is one"
 msgstr ""
 "Vérifier les mises à jour de %s, et lance le téléchargement s’il en existe "
 "une"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:840
+#: addon\globalPlugins\brailleExtender\__init__.py:841
 msgid "Increase autoscroll delay"
 msgstr "Augmenter le délai du défilement automatique"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:841
+#: addon\globalPlugins\brailleExtender\__init__.py:842
 msgid "Decrease autoscroll delay"
 msgstr "Diminuer le délai du défilement automatique"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:845
-#: addon\globalPlugins\brailleExtender\__init__.py:863
+#: addon\globalPlugins\brailleExtender\__init__.py:846
+#: addon\globalPlugins\brailleExtender\__init__.py:864
 msgid "Please use NVDA 2017.3 minimum for this feature"
 msgstr "Veuillez utiliser NVDA 2017.3 pour cette fonctionnalité"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:847
-#: addon\globalPlugins\brailleExtender\__init__.py:865
+#: addon\globalPlugins\brailleExtender\__init__.py:848
+#: addon\globalPlugins\brailleExtender\__init__.py:866
 msgid ""
 "You must choose at least two tables for this feature. Please fill in the "
 "settings"
@@ -554,49 +554,49 @@ msgstr ""
 "Vous devez choisir au moins deux tables pour cette fonctionnalité. Merci de "
 "les renseigner dans les paramètres"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:854
+#: addon\globalPlugins\brailleExtender\__init__.py:855
 #, python-format
 msgid "Input: %s"
 msgstr "Saisie : %s"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:858
+#: addon\globalPlugins\brailleExtender\__init__.py:859
 msgid "Switch between his favorite input braille tables"
 msgstr "Boucler entre ses tables braille d’entrer"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:873
+#: addon\globalPlugins\brailleExtender\__init__.py:874
 #, python-format
 msgid "Output: %s"
 msgstr "Affichage : %s"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:876
+#: addon\globalPlugins\brailleExtender\__init__.py:877
 msgid "Switch between his favorite output braille tables"
 msgstr "Boucler entre ses tables de sortie"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:882
+#: addon\globalPlugins\brailleExtender\__init__.py:883
 #, python-brace-format
 msgid "I⣿O:{I}"
 msgstr "E⣿S:{I}"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:883
+#: addon\globalPlugins\brailleExtender\__init__.py:884
 #, python-brace-format
 msgid "Input and output: {I}."
 msgstr "Saisie et affichage: {I}."
 
-#: addon\globalPlugins\brailleExtender\__init__.py:885
+#: addon\globalPlugins\brailleExtender\__init__.py:886
 #, python-brace-format
 msgid "I:{I} ⣿ O: {O}"
 msgstr "A: {O} ⣿ S:{I}"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:886
+#: addon\globalPlugins\brailleExtender\__init__.py:887
 #, python-brace-format
 msgid "Input: {I}; Output: {O}"
 msgstr "Affichage : {O} ; Saisie: {I}"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:890
+#: addon\globalPlugins\brailleExtender\__init__.py:891
 msgid "Announce the current input and output braille tables"
 msgstr "Annoncez les tables braille d’entrée et de sortie actuelles"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:895
+#: addon\globalPlugins\brailleExtender\__init__.py:896
 msgid ""
 "Gives the Unicode value of the character where the cursor is located and the "
 "decimal, binary and octal equivalent."
@@ -604,7 +604,7 @@ msgstr ""
 "Obtenir la valeur Unicode du caractère sur lequel le curseur se trouve ainsi "
 "que l’équivalent en décimale, binaire et octale."
 
-#: addon\globalPlugins\brailleExtender\__init__.py:903
+#: addon\globalPlugins\brailleExtender\__init__.py:904
 msgid ""
 "Show the output speech for selected text in braille. Useful for emojis for "
 "example"
@@ -612,37 +612,37 @@ msgstr ""
 "Affiche l'énoncé vocal pour le texte sélectionné en braille. Pratique pour "
 "les emojis par exemple"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:907
+#: addon\globalPlugins\brailleExtender\__init__.py:908
 msgid "No shortcut performed from a braille display"
 msgstr "Aucun raccourci effectué depuis un afficheur braille"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:913
+#: addon\globalPlugins\brailleExtender\__init__.py:914
 msgid "Repeat the last shortcut performed from a braille display"
 msgstr "Répéter le dernier raccourci effectué depuis un afficheur braille"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:930
+#: addon\globalPlugins\brailleExtender\__init__.py:931
 #, python-format
 msgid "%s reloaded"
 msgstr "%s rechargé"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:945
+#: addon\globalPlugins\brailleExtender\__init__.py:946
 #, python-format
 msgid "Reload %s"
 msgstr "Recharger %s"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:948
+#: addon\globalPlugins\brailleExtender\__init__.py:949
 msgid "Reload the first braille display defined in settings"
 msgstr "Recharger le premier afficheur braille défini dans les paramètres"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:951
+#: addon\globalPlugins\brailleExtender\__init__.py:952
 msgid "Reload the second braille display defined in settings"
 msgstr "Recharger le second afficheur braille défini dans les paramètres"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:957
+#: addon\globalPlugins\brailleExtender\__init__.py:958
 msgid "No braille display specified. No reload to do"
 msgstr "Pas d’afficheur braille spécifié. Aucun rechargement à effectuer"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1030
+#: addon\globalPlugins\brailleExtender\__init__.py:1031
 msgid ""
 "You should specify a braille table for shortcuts when you work with a "
 "contracted input. Please go in the settings"
@@ -651,91 +651,91 @@ msgstr ""
 "travaillez avec une entrée contractée. Veuillez vous rendre dans les "
 "paramètres"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1038
+#: addon\globalPlugins\brailleExtender\__init__.py:1039
 #, python-format
 msgid "Unable to send %s"
 msgstr "Impossible d’effectuer %s"
 
 #. and 'nvda' in sht.lower()
-#: addon\globalPlugins\brailleExtender\__init__.py:1040
+#: addon\globalPlugins\brailleExtender\__init__.py:1041
 #, python-format
 msgid "%s is not part of a NVDA commands"
 msgstr "%s ne fait pas partie des commandes NVDA de base"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1132
+#: addon\globalPlugins\brailleExtender\__init__.py:1133
 msgid "WIN"
 msgstr ""
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1133
+#: addon\globalPlugins\brailleExtender\__init__.py:1134
 msgid "CTRL"
 msgstr ""
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1134
+#: addon\globalPlugins\brailleExtender\__init__.py:1135
 msgid "SHIFT"
 msgstr "MAJ"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1135
+#: addon\globalPlugins\brailleExtender\__init__.py:1136
 msgid "ALT"
 msgstr ""
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1238
+#: addon\globalPlugins\brailleExtender\__init__.py:1239
 msgid "Keyboard shortcut cancelled"
 msgstr "Raccourci clavier annulé"
 
 #. /* docstrings for modifier keys */
-#: addon\globalPlugins\brailleExtender\__init__.py:1248
+#: addon\globalPlugins\brailleExtender\__init__.py:1249
 msgid "Emulate pressing down "
 msgstr "Émuler l’appui maintenu de "
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1249
+#: addon\globalPlugins\brailleExtender\__init__.py:1250
 msgid " on the system keyboard"
 msgstr " sur le clavier du système"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1329
+#: addon\globalPlugins\brailleExtender\__init__.py:1330
 msgid "Current braille view saved"
 msgstr "Vue braille actuelle sauvegardée"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1332
+#: addon\globalPlugins\brailleExtender\__init__.py:1333
 msgid "Buffer cleaned"
 msgstr "Tampon vidé"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1333
+#: addon\globalPlugins\brailleExtender\__init__.py:1334
 msgid "Save the current braille view. Press twice quickly to clean the buffer"
 msgstr ""
 "Sauvegardez la vue braille actuelle. Appuyez deux fois rapidement pour "
 "effacer le tampon"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1338
+#: addon\globalPlugins\brailleExtender\__init__.py:1339
 msgid "View saved"
 msgstr "Vue sauvegardée"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1339
+#: addon\globalPlugins\brailleExtender\__init__.py:1340
 msgid "Buffer empty"
 msgstr "Tampon vide"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1340
+#: addon\globalPlugins\brailleExtender\__init__.py:1341
 msgid "Show the saved braille view through a flash message."
 msgstr "Afficher la vue braille enregistrée via un message flash."
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1374
+#: addon\globalPlugins\brailleExtender\__init__.py:1375
 msgid "Pause"
 msgstr "Pause"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1374
+#: addon\globalPlugins\brailleExtender\__init__.py:1375
 msgid "Resume"
 msgstr "Reprendre"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1416
-#: addon\globalPlugins\brailleExtender\__init__.py:1423
+#: addon\globalPlugins\brailleExtender\__init__.py:1417
+#: addon\globalPlugins\brailleExtender\__init__.py:1424
 #, python-format
 msgid "Auto test type %d"
 msgstr "Auto test %d"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1433
+#: addon\globalPlugins\brailleExtender\__init__.py:1434
 msgid "Auto test stopped"
 msgstr "Défilement automatique arrêté"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1443
+#: addon\globalPlugins\brailleExtender\__init__.py:1444
 msgid ""
 "Auto test started. Use the up and down arrow keys to change speed. Use the "
 "left and right arrow keys to change test type. Use space key to pause or "
@@ -746,14 +746,14 @@ msgstr ""
 "de test. Utilisez la touche espace pour faire une pause ou reprendre le "
 "test. Utilisez la touche d’échappement pour quitter"
 
-#: addon\globalPlugins\brailleExtender\__init__.py:1445
+#: addon\globalPlugins\brailleExtender\__init__.py:1446
 msgid "Auto test"
 msgstr "Auto test"
 
 #. Add-on summary, usually the user visible name of the addon.
 #. Translators: Summary for this add-on to be shown on installation and add-on information.
-#: addon\globalPlugins\brailleExtender\__init__.py:1494
-#: addon\globalPlugins\brailleExtender\settings.py:30 buildVars.py:18
+#: addon\globalPlugins\brailleExtender\__init__.py:1495
+#: addon\globalPlugins\brailleExtender\settings.py:31 buildVars.py:18
 #, fuzzy
 #| msgid "BrailleExtender"
 msgid "Braille Extender"
@@ -847,7 +847,7 @@ msgid "Standard NVDA commands"
 msgstr "Commandes NVDA standards"
 
 #: addon\globalPlugins\brailleExtender\addonDoc.py:88
-#: addon\globalPlugins\brailleExtender\settings.py:793
+#: addon\globalPlugins\brailleExtender\settings.py:804
 msgid "Modifier keys"
 msgstr "Touches de modification"
 
@@ -928,63 +928,59 @@ msgstr "description actuellement indisponible pour ce raccourci"
 msgid "caps lock"
 msgstr "verrouillage majuscules"
 
-#: addon\globalPlugins\brailleExtender\configBE.py:42
-#: addon\globalPlugins\brailleExtender\configBE.py:49
-#: addon\globalPlugins\brailleExtender\configBE.py:62
-#: addon\globalPlugins\brailleExtender\settings.py:478
+#: addon\globalPlugins\brailleExtender\configBE.py:45
+#: addon\globalPlugins\brailleExtender\configBE.py:52
+#: addon\globalPlugins\brailleExtender\configBE.py:66
+#: addon\globalPlugins\brailleExtender\settings.py:476
 msgid "none"
 msgstr "aucun"
 
-#: addon\globalPlugins\brailleExtender\configBE.py:43
+#: addon\globalPlugins\brailleExtender\configBE.py:46
 msgid "braille only"
 msgstr "braille seulement"
 
-#: addon\globalPlugins\brailleExtender\configBE.py:44
+#: addon\globalPlugins\brailleExtender\configBE.py:47
 msgid "speech only"
 msgstr "parole seulement"
 
-#: addon\globalPlugins\brailleExtender\configBE.py:45
-#: addon\globalPlugins\brailleExtender\configBE.py:65
+#: addon\globalPlugins\brailleExtender\configBE.py:48
+#: addon\globalPlugins\brailleExtender\configBE.py:69
 msgid "both"
 msgstr "les deux"
 
-#: addon\globalPlugins\brailleExtender\configBE.py:50
+#: addon\globalPlugins\brailleExtender\configBE.py:53
 msgid "dots 7 and 8"
 msgstr "points 7 et 8"
 
-#: addon\globalPlugins\brailleExtender\configBE.py:51
+#: addon\globalPlugins\brailleExtender\configBE.py:54
 msgid "dot 7"
 msgstr "point 7"
 
-#: addon\globalPlugins\brailleExtender\configBE.py:52
+#: addon\globalPlugins\brailleExtender\configBE.py:55
 msgid "dot 8"
 msgstr "point 8"
 
-#: addon\globalPlugins\brailleExtender\configBE.py:56
+#: addon\globalPlugins\brailleExtender\configBE.py:61
 msgid "stable"
 msgstr "stable"
 
-#: addon\globalPlugins\brailleExtender\configBE.py:57
-msgid "testing"
-msgstr "test"
-
-#: addon\globalPlugins\brailleExtender\configBE.py:58
+#: addon\globalPlugins\brailleExtender\configBE.py:62
 msgid "development"
 msgstr "développement"
 
-#: addon\globalPlugins\brailleExtender\configBE.py:63
+#: addon\globalPlugins\brailleExtender\configBE.py:67
 msgid "focus mode"
 msgstr "mode focus"
 
-#: addon\globalPlugins\brailleExtender\configBE.py:64
+#: addon\globalPlugins\brailleExtender\configBE.py:68
 msgid "review mode"
 msgstr "mode revue"
 
-#: addon\globalPlugins\brailleExtender\configBE.py:102
+#: addon\globalPlugins\brailleExtender\configBE.py:109
 msgid "last known"
 msgstr "Dernier connu"
 
-#: addon\globalPlugins\brailleExtender\patchs.py:146
+#: addon\globalPlugins\brailleExtender\patchs.py:160
 msgid ""
 "An unexpected error was produced while using several braille tables. Using "
 "default settings to avoid other errors. More information in NVDA log. Thanks "
@@ -994,197 +990,197 @@ msgstr ""
 "tables braille. Utilisation des paramètres par défaut pour éviter d’autres "
 "erreurs. Plus d'informations dans le journal NVDA. Merci de le signaler."
 
-#: addon\globalPlugins\brailleExtender\settings.py:30
+#: addon\globalPlugins\brailleExtender\settings.py:31
 msgid "The feature implementation is in progress. Thanks for your patience."
 msgstr ""
 "L'implémentation de cette fonctionnalité est en cours. Merci pour votre "
 "patience."
 
-#: addon\globalPlugins\brailleExtender\settings.py:52
+#: addon\globalPlugins\brailleExtender\settings.py:53
 msgid "feature in process"
 msgstr "fonctionnalité en cours"
 
 #. Translators: title of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:88
-#: addon\globalPlugins\brailleExtender\settings.py:254
+#: addon\globalPlugins\brailleExtender\settings.py:89
+#: addon\globalPlugins\brailleExtender\settings.py:255
 msgid "General"
 msgstr "Général"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:95
+#: addon\globalPlugins\brailleExtender\settings.py:96
 msgid "Check for &updates automatically"
 msgstr "Vérifier les &mise à jour automatiquement"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:99
+#: addon\globalPlugins\brailleExtender\settings.py:100
 msgid "Add-on update channel"
 msgstr "Canal de mise à jour"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:106
+#: addon\globalPlugins\brailleExtender\settings.py:107
 msgid "Say current line while scrolling in"
 msgstr "Énoncer la ligne actuelle lors du défilement en"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:110
+#: addon\globalPlugins\brailleExtender\settings.py:111
 msgid "Speech interrupt when scrolling on same line"
 msgstr "Interruption de la parole lors du défilement sur une même ligne"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:114
+#: addon\globalPlugins\brailleExtender\settings.py:115
 msgid "Speech interrupt for unknown gestures"
-msgstr "Ne pas interrompre la parole lors de gestes inconnus"
+msgstr "Interrompre la parole lors de gestes inconnus"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:118
+#: addon\globalPlugins\brailleExtender\settings.py:119
 msgid "Announce the character while moving with routing buttons"
 msgstr "Annoncer le caractère lors du déplacement avec les boutons de routage"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:122
+#: addon\globalPlugins\brailleExtender\settings.py:123
 msgid "Use cursor keys to route cursor in review mode"
 msgstr "En mode revue, utiliser les flèches pour déplacer le curseur"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:126
+#: addon\globalPlugins\brailleExtender\settings.py:127
 msgid "Display time and date infinitely"
 msgstr "Afficher l’heure et la date infiniment"
 
-#: addon\globalPlugins\brailleExtender\settings.py:128
+#: addon\globalPlugins\brailleExtender\settings.py:129
 msgid "Automatic review mode for apps with terminal"
 msgstr "Mode de révision automatique pour les applications avec terminal"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:132
+#: addon\globalPlugins\brailleExtender\settings.py:133
 msgid "Feedback for volume change in"
 msgstr "Retour pour le changement de volume en"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:140
+#: addon\globalPlugins\brailleExtender\settings.py:141
 msgid "Feedback for modifier keys in"
 msgstr "Retour pour les touches de modification en"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:146
+#: addon\globalPlugins\brailleExtender\settings.py:147
 msgid "Play beeps for modifier keys"
 msgstr "Jouer des bips pour les touches de modification"
 
-#: addon\globalPlugins\brailleExtender\settings.py:151
+#: addon\globalPlugins\brailleExtender\settings.py:152
 msgid "Right margin on cells"
 msgstr "Marge droite sur les cellules"
 
-#: addon\globalPlugins\brailleExtender\settings.py:151
-#: addon\globalPlugins\brailleExtender\settings.py:163
-#: addon\globalPlugins\brailleExtender\settings.py:412
+#: addon\globalPlugins\brailleExtender\settings.py:152
+#: addon\globalPlugins\brailleExtender\settings.py:164
+#: addon\globalPlugins\brailleExtender\settings.py:410
 msgid "for the currrent braille display"
 msgstr "pour l’afficheur braille actuel"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:155
+#: addon\globalPlugins\brailleExtender\settings.py:156
 msgid "Braille keyboard configuration"
 msgstr "Configuration du clavier braille"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:159
+#: addon\globalPlugins\brailleExtender\settings.py:160
 msgid "Reverse forward scroll and back scroll buttons"
 msgstr "Inverser les boutons de défilement arrière et avant"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:163
+#: addon\globalPlugins\brailleExtender\settings.py:164
 msgid "Autoscroll delay (ms)"
 msgstr "Délai pour l’auto-défilement (ms)"
 
-#: addon\globalPlugins\brailleExtender\settings.py:164
+#: addon\globalPlugins\brailleExtender\settings.py:165
 msgid "First braille display preferred"
 msgstr "Premier afficheur braille préféré"
 
-#: addon\globalPlugins\brailleExtender\settings.py:166
+#: addon\globalPlugins\brailleExtender\settings.py:167
 msgid "Second braille display preferred"
 msgstr "Second afficheur braille préféré"
 
 #. Translators: title of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:200
+#: addon\globalPlugins\brailleExtender\settings.py:201
 msgid "Attribra"
 msgstr ""
 
-#: addon\globalPlugins\brailleExtender\settings.py:204
+#: addon\globalPlugins\brailleExtender\settings.py:205
 msgid "Enable Attribra"
 msgstr "Activer Attribra"
 
-#: addon\globalPlugins\brailleExtender\settings.py:206
+#: addon\globalPlugins\brailleExtender\settings.py:207
 msgid "Show spelling errors with"
 msgstr "Montrer les erreurs d’orthographe avec"
 
-#: addon\globalPlugins\brailleExtender\settings.py:208
+#: addon\globalPlugins\brailleExtender\settings.py:209
 msgid "Show bold with"
 msgstr "Montrer la mise en gras avec"
 
-#: addon\globalPlugins\brailleExtender\settings.py:210
+#: addon\globalPlugins\brailleExtender\settings.py:211
 msgid "Show italic with"
 msgstr "Montrer la mise en italique avec"
 
-#: addon\globalPlugins\brailleExtender\settings.py:212
+#: addon\globalPlugins\brailleExtender\settings.py:213
 msgid "Show underline with"
 msgstr "Montrer la mise en souligné avec"
 
-#: addon\globalPlugins\brailleExtender\settings.py:214
+#: addon\globalPlugins\brailleExtender\settings.py:215
 msgid "Show strikethrough with"
 msgstr "Montrer les biffures avec"
 
-#: addon\globalPlugins\brailleExtender\settings.py:216
+#: addon\globalPlugins\brailleExtender\settings.py:217
 msgid "Show subscript with"
 msgstr "Montrer la mise en indice avec"
 
-#: addon\globalPlugins\brailleExtender\settings.py:218
+#: addon\globalPlugins\brailleExtender\settings.py:219
 msgid "Show superscript with"
 msgstr "Montrer la mise en exposant avec"
 
 #. Translators: title of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:245
+#: addon\globalPlugins\brailleExtender\settings.py:246
 msgid "Role labels"
 msgstr "Étiquettes de rôle"
 
-#: addon\globalPlugins\brailleExtender\settings.py:252
+#: addon\globalPlugins\brailleExtender\settings.py:253
 msgid "Enable this feature"
 msgstr "Activer cette fonctionnalité"
 
-#: addon\globalPlugins\brailleExtender\settings.py:254
+#: addon\globalPlugins\brailleExtender\settings.py:255
 msgid "Role category"
 msgstr "Catégorie de rôle"
 
-#: addon\globalPlugins\brailleExtender\settings.py:254
+#: addon\globalPlugins\brailleExtender\settings.py:255
 msgid "Landmark"
 msgstr "Repère"
 
-#: addon\globalPlugins\brailleExtender\settings.py:254
+#: addon\globalPlugins\brailleExtender\settings.py:255
 msgid "Positive state"
 msgstr "État positif"
 
-#: addon\globalPlugins\brailleExtender\settings.py:254
+#: addon\globalPlugins\brailleExtender\settings.py:255
 msgid "Negative state"
 msgstr "État négatif"
 
-#: addon\globalPlugins\brailleExtender\settings.py:258
+#: addon\globalPlugins\brailleExtender\settings.py:259
 msgid "Role"
 msgstr "Rôle"
 
-#: addon\globalPlugins\brailleExtender\settings.py:260
+#: addon\globalPlugins\brailleExtender\settings.py:261
 msgid "Actual or new label"
 msgstr "Étiquette actuelle ou nouvelle"
 
-#: addon\globalPlugins\brailleExtender\settings.py:264
+#: addon\globalPlugins\brailleExtender\settings.py:265
 msgid "&Reset this role label"
 msgstr "&Réinitialiser cette étiquette de rôle"
 
-#: addon\globalPlugins\brailleExtender\settings.py:266
+#: addon\globalPlugins\brailleExtender\settings.py:267
 msgid "Reset all role labels"
 msgstr "Réinitialiser toutes les étiquettes de rôle"
 
-#: addon\globalPlugins\brailleExtender\settings.py:331
+#: addon\globalPlugins\brailleExtender\settings.py:332
 msgid "You have no customized label."
 msgstr "Vous n’avez aucune étiquette personnalisée."
 
-#: addon\globalPlugins\brailleExtender\settings.py:334
+#: addon\globalPlugins\brailleExtender\settings.py:335
 #, python-format
 msgid ""
 "Do you want really reset all labels? Currently, you have %d customized "
@@ -1193,100 +1189,102 @@ msgstr ""
 "Voulez-vous vraiment réinitialiser toutes les étiquettes ? Actuellement, "
 "vous avez %d étiquettes personnalisées."
 
-#: addon\globalPlugins\brailleExtender\settings.py:335
-#: addon\globalPlugins\brailleExtender\settings.py:700
+#: addon\globalPlugins\brailleExtender\settings.py:336
+#: addon\globalPlugins\brailleExtender\settings.py:711
 msgid "Confirmation"
 msgstr "Confirmation"
 
 #. Translators: title of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:381
+#: addon\globalPlugins\brailleExtender\settings.py:379
 msgid "braille tables"
 msgstr "tables braille"
 
-#: addon\globalPlugins\brailleExtender\settings.py:386
+#: addon\globalPlugins\brailleExtender\settings.py:384
 msgid "Use the current input table"
 msgstr "Utiliser la table braille d’entrée actuelle"
 
-#: addon\globalPlugins\brailleExtender\settings.py:395
+#: addon\globalPlugins\brailleExtender\settings.py:393
 msgid "Prefered braille tables"
 msgstr "Tables braille préférées"
 
-#: addon\globalPlugins\brailleExtender\settings.py:395
+#: addon\globalPlugins\brailleExtender\settings.py:393
 msgid "press F1 for help"
 msgstr "pressez F1 pour de l’aide"
 
-#: addon\globalPlugins\brailleExtender\settings.py:399
+#: addon\globalPlugins\brailleExtender\settings.py:397
 msgid "Input braille table for keyboard shortcut keys"
 msgstr "Table braille d’entrée pour les raccourcis clavier"
 
-#: addon\globalPlugins\brailleExtender\settings.py:401
+#: addon\globalPlugins\brailleExtender\settings.py:399
 msgid "None"
 msgstr "Aucune"
 
-#: addon\globalPlugins\brailleExtender\settings.py:404
+#: addon\globalPlugins\brailleExtender\settings.py:402
 msgid "Secondary output table to use"
 msgstr "Table braille secondaire à utiliser"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:408
+#: addon\globalPlugins\brailleExtender\settings.py:406
 msgid "Display tab signs as spaces"
 msgstr "Afficher les signes de tabulation en tant qu’espaces"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:412
+#: addon\globalPlugins\brailleExtender\settings.py:410
 msgid "Number of space for a tab sign"
 msgstr "Nombre d’espaces pour un signe de tabulation"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:414
+#: addon\globalPlugins\brailleExtender\settings.py:412
 msgid "Prevent undefined characters with Hexadecimal Unicode value"
 msgstr ""
 "Empêcher les caractères non définis avec leur valeur hexadécimale Unicode"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:417
+#: addon\globalPlugins\brailleExtender\settings.py:415
 msgid ""
 "Show undefined characters as (e.g.: 0 for blank cell, 12345678, 6-123456)"
 msgstr ""
 "Afficher les caractères non définis comme (p. ex. : 0 pour une cellule vide, "
 "12345678, 6-123456)"
 
-#: addon\globalPlugins\brailleExtender\settings.py:419
-msgid "&Custom braille tables"
+#: addon\globalPlugins\brailleExtender\settings.py:417
+#, fuzzy
+#| msgid "&Custom braille tables"
+msgid "Alternative and &custom braille tables"
 msgstr "Tables braille personnalisées"
 
-#: addon\globalPlugins\brailleExtender\settings.py:477
+#: addon\globalPlugins\brailleExtender\settings.py:475
 msgid "input and output"
 msgstr "saisie et affichage"
 
-#: addon\globalPlugins\brailleExtender\settings.py:479
+#: addon\globalPlugins\brailleExtender\settings.py:477
 msgid "input only"
 msgstr "saisie seulement"
 
-#: addon\globalPlugins\brailleExtender\settings.py:480
+#: addon\globalPlugins\brailleExtender\settings.py:478
 msgid "output only"
 msgstr "affichage seulement"
 
-#: addon\globalPlugins\brailleExtender\settings.py:511
+#: addon\globalPlugins\brailleExtender\settings.py:509
 #, python-format
 msgid "Table name: %s"
 msgstr "Nom de la table : %s"
 
-#: addon\globalPlugins\brailleExtender\settings.py:512
+#: addon\globalPlugins\brailleExtender\settings.py:510
 #, python-format
 msgid "File name: %s"
 msgstr "Nom du fichier : %s"
 
-#: addon\globalPlugins\brailleExtender\settings.py:513
+#: addon\globalPlugins\brailleExtender\settings.py:511
 #, python-format
 msgid "In switches: %s"
 msgstr "Dans les commutateurs : %s"
 
-#: addon\globalPlugins\brailleExtender\settings.py:514
+#: addon\globalPlugins\brailleExtender\settings.py:512
 msgid "About this table"
 msgstr "À propos de cette table"
 
-#: addon\globalPlugins\brailleExtender\settings.py:517
+#: addon\globalPlugins\brailleExtender\settings.py:515
 msgid ""
 "In this combo box, all tables are present. Press space bar, left or right "
 "arrow keys to include (or not) the selected table in switches"
@@ -1295,7 +1293,7 @@ msgstr ""
 "Appuyez sur la barre d’espace, les flèches gauche ou droite pour inclure (ou "
 "non) la table sélectionnée dans les commutateurs"
 
-#: addon\globalPlugins\brailleExtender\settings.py:518
+#: addon\globalPlugins\brailleExtender\settings.py:516
 msgid ""
 "You can also press 'comma' key to get the file name of the selected table "
 "and 'semicolon' key to view miscellaneous infos on the selected table"
@@ -1304,122 +1302,126 @@ msgstr ""
 "du fichier de la table sélectionnée et sur la touche « point-virgule » pour "
 "afficher diverses informations sur la table sélectionnée"
 
-#: addon\globalPlugins\brailleExtender\settings.py:519
+#: addon\globalPlugins\brailleExtender\settings.py:517
 msgid "Contextual help"
 msgstr "Aide contextuelle"
 
 #. Translators: title of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:534
+#: addon\globalPlugins\brailleExtender\settings.py:532
 msgid "Custom braille tables"
 msgstr "Tables braille personnalisées"
 
-#: addon\globalPlugins\brailleExtender\settings.py:541
+#: addon\globalPlugins\brailleExtender\settings.py:542
 msgid "Use a custom table as input table"
 msgstr "Utiliser une table personnalisée en tant que table de saisie"
 
-#: addon\globalPlugins\brailleExtender\settings.py:542
+#: addon\globalPlugins\brailleExtender\settings.py:543
 msgid "Use a custom table as output table"
 msgstr "Utiliser une table personnalisée comme table d'affichage"
 
-#: addon\globalPlugins\brailleExtender\settings.py:543
+#: addon\globalPlugins\brailleExtender\settings.py:544
 msgid "&Add a braille table"
 msgstr "&Ajouter une table braille"
 
 #. Translators: title of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:559
+#: addon\globalPlugins\brailleExtender\settings.py:568
 msgid "Add a braille table"
 msgstr "Ajouter une table braille"
 
-#: addon\globalPlugins\brailleExtender\settings.py:565
+#: addon\globalPlugins\brailleExtender\settings.py:574
 msgid "Display name"
 msgstr "Nom d'affichage"
 
-#: addon\globalPlugins\brailleExtender\settings.py:566
+#: addon\globalPlugins\brailleExtender\settings.py:575
+msgid "Description"
+msgstr ""
+
+#: addon\globalPlugins\brailleExtender\settings.py:576
 msgid "Path"
 msgstr "Répertoire"
 
-#: addon\globalPlugins\brailleExtender\settings.py:567
-#: addon\globalPlugins\brailleExtender\settings.py:638
+#: addon\globalPlugins\brailleExtender\settings.py:577
+#: addon\globalPlugins\brailleExtender\settings.py:648
 msgid "&Browse"
 msgstr "&Parcourir"
 
-#: addon\globalPlugins\brailleExtender\settings.py:570
+#: addon\globalPlugins\brailleExtender\settings.py:580
 msgid "Contracted (grade 2) braille table"
 msgstr "Table braille abrégé (grade 2)"
 
 #. Translators: label of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:572
+#: addon\globalPlugins\brailleExtender\settings.py:582
 msgid "Available for"
 msgstr "Disponible pour"
 
-#: addon\globalPlugins\brailleExtender\settings.py:572
+#: addon\globalPlugins\brailleExtender\settings.py:582
 msgid "Input and output"
 msgstr "Saisie et affichage"
 
-#: addon\globalPlugins\brailleExtender\settings.py:572
+#: addon\globalPlugins\brailleExtender\settings.py:582
 msgid "Input only"
 msgstr "Saisie seulement"
 
-#: addon\globalPlugins\brailleExtender\settings.py:572
+#: addon\globalPlugins\brailleExtender\settings.py:582
 msgid "Output only"
 msgstr "Affichage seulement"
 
-#: addon\globalPlugins\brailleExtender\settings.py:578
+#: addon\globalPlugins\brailleExtender\settings.py:588
 msgid "Choose a table file"
 msgstr "Choisissez un fichier de table"
 
-#: addon\globalPlugins\brailleExtender\settings.py:578
+#: addon\globalPlugins\brailleExtender\settings.py:588
 msgid "Liblouis table files"
 msgstr "Fichiers de table Liblouis"
 
-#: addon\globalPlugins\brailleExtender\settings.py:590
+#: addon\globalPlugins\brailleExtender\settings.py:600
 msgid "Please specify a display name."
 msgstr "Veuillez spécifier un nom d'affichage."
 
-#: addon\globalPlugins\brailleExtender\settings.py:590
+#: addon\globalPlugins\brailleExtender\settings.py:600
 msgid "Invalid display name"
 msgstr "Nom d'affichage invalide"
 
-#: addon\globalPlugins\brailleExtender\settings.py:594
+#: addon\globalPlugins\brailleExtender\settings.py:604
 #, python-format
 msgid "The specified path is not valid (%s)."
 msgstr "Le répertoire spécifié est invalide (%s)."
 
-#: addon\globalPlugins\brailleExtender\settings.py:594
+#: addon\globalPlugins\brailleExtender\settings.py:604
 msgid "Invalid path"
 msgstr "Répertoire invalide"
 
 #. Translators: title of a dialog.
-#: addon\globalPlugins\brailleExtender\settings.py:622
+#: addon\globalPlugins\brailleExtender\settings.py:632
 msgid "Quick launches"
 msgstr "Lancements rapides"
 
-#: addon\globalPlugins\brailleExtender\settings.py:633
+#: addon\globalPlugins\brailleExtender\settings.py:643
 msgid "&Gestures"
 msgstr "&Gestes"
 
-#: addon\globalPlugins\brailleExtender\settings.py:636
+#: addon\globalPlugins\brailleExtender\settings.py:646
 msgid "Location (file path, URL or command)"
 msgstr "Emplacement (chemin de fichier, URL ou commande)"
 
-#: addon\globalPlugins\brailleExtender\settings.py:639
+#: addon\globalPlugins\brailleExtender\settings.py:649
 msgid "&Remove this gesture"
 msgstr "&Supprimer ce geste"
 
-#: addon\globalPlugins\brailleExtender\settings.py:640
+#: addon\globalPlugins\brailleExtender\settings.py:650
 msgid "&Add a quick launch"
 msgstr "&Ajouter un lancement rapide"
 
-#: addon\globalPlugins\brailleExtender\settings.py:669
+#: addon\globalPlugins\brailleExtender\settings.py:679
 msgid "Unable to associate this gesture. Please enter another, now"
 msgstr ""
 "Impossible d’associer ce geste. Veuillez en entrer un autre, maintenant"
 
-#: addon\globalPlugins\brailleExtender\settings.py:674
+#: addon\globalPlugins\brailleExtender\settings.py:684
 msgid "Out of capture"
 msgstr "Hors de capture"
 
-#: addon\globalPlugins\brailleExtender\settings.py:676
+#: addon\globalPlugins\brailleExtender\settings.py:686
 #, python-brace-format
 msgid ""
 "Please enter a gesture from your {NAME_BRAILLE_DISPLAY} braille display. "
@@ -1428,21 +1430,21 @@ msgstr ""
 "Veuillez entrer un geste depuis votre afficheur braille "
 "{NAME_BRAILLE_DISPLAY}. Appuyez sur espace pour annuler."
 
-#: addon\globalPlugins\brailleExtender\settings.py:685
+#: addon\globalPlugins\brailleExtender\settings.py:695
 #, python-format
 msgid "OK. The gesture captured is %s"
 msgstr "OK. Le geste capturé est %s"
 
-#: addon\globalPlugins\brailleExtender\settings.py:700
+#: addon\globalPlugins\brailleExtender\settings.py:711
 msgid "Are you sure to want to delete this shorcut?"
 msgstr "Êtes-vous sûr de vouloir supprimer ce raccourci ?"
 
-#: addon\globalPlugins\brailleExtender\settings.py:709
+#: addon\globalPlugins\brailleExtender\settings.py:720
 #, python-brace-format
 msgid "{BRAILLEGESTURE} removed"
 msgstr "{BRAILLEGESTURE} supprimé"
 
-#: addon\globalPlugins\brailleExtender\settings.py:720
+#: addon\globalPlugins\brailleExtender\settings.py:731
 msgid ""
 "Please enter the desired gesture for the new quick launch. Press \"space bar"
 "\" to cancel"
@@ -1450,115 +1452,115 @@ msgstr ""
 "Veuillez entrer le geste souhaité pour ce nouveau lancement rapide. Pressez "
 "\"barre espace\" pour annuler."
 
-#: addon\globalPlugins\brailleExtender\settings.py:723
+#: addon\globalPlugins\brailleExtender\settings.py:734
 msgid "Don't add a quick launch"
 msgstr "Ne pas ajouter de lancement rapide"
 
-#: addon\globalPlugins\brailleExtender\settings.py:749
+#: addon\globalPlugins\brailleExtender\settings.py:760
 #, python-brace-format
 msgid "Choose a file for {0}"
 msgstr "Choisissez un fichier pour {0}"
 
-#: addon\globalPlugins\brailleExtender\settings.py:762
+#: addon\globalPlugins\brailleExtender\settings.py:773
 msgid "Please create or select a quick launch first"
 msgstr "Veuillez d'abord créer ou sélectionner un lancement rapide"
 
-#: addon\globalPlugins\brailleExtender\settings.py:762
+#: addon\globalPlugins\brailleExtender\settings.py:773
 msgid "Error"
 msgstr "Erreur"
 
-#: addon\globalPlugins\brailleExtender\settings.py:766
+#: addon\globalPlugins\brailleExtender\settings.py:777
 msgid "Profiles editor"
 msgstr "Éditeur de profils"
 
-#: addon\globalPlugins\brailleExtender\settings.py:776
+#: addon\globalPlugins\brailleExtender\settings.py:787
 msgid "You must have a braille display to editing a profile"
 msgstr "Vous devez avoir un afficheur braille pour modifier un profil"
 
-#: addon\globalPlugins\brailleExtender\settings.py:780
+#: addon\globalPlugins\brailleExtender\settings.py:791
 msgid ""
 "Profiles directory is not present or accessible. Unable to edit profiles"
 msgstr ""
 "Le répertoire des profils n’est pas présent ou accessible. Impossible de "
 "modifier les profils"
 
-#: addon\globalPlugins\brailleExtender\settings.py:786
+#: addon\globalPlugins\brailleExtender\settings.py:797
 msgid "Profile to edit"
 msgstr "Profil à éditer"
 
-#: addon\globalPlugins\brailleExtender\settings.py:792
+#: addon\globalPlugins\brailleExtender\settings.py:803
 msgid "Gestures category"
 msgstr "Catégorie de gestes"
 
-#: addon\globalPlugins\brailleExtender\settings.py:793
+#: addon\globalPlugins\brailleExtender\settings.py:804
 msgid "Single keys"
 msgstr "Touches simples"
 
-#: addon\globalPlugins\brailleExtender\settings.py:793
+#: addon\globalPlugins\brailleExtender\settings.py:804
 msgid "Practical shortcuts"
 msgstr "Raccourcis usuels"
 
-#: addon\globalPlugins\brailleExtender\settings.py:793
+#: addon\globalPlugins\brailleExtender\settings.py:804
 msgid "NVDA commands"
 msgstr "Commandes NVDA"
 
-#: addon\globalPlugins\brailleExtender\settings.py:793
+#: addon\globalPlugins\brailleExtender\settings.py:804
 msgid "Addon features"
 msgstr "Fonctionnalités du module"
 
-#: addon\globalPlugins\brailleExtender\settings.py:797
+#: addon\globalPlugins\brailleExtender\settings.py:808
 msgid "Gestures list"
 msgstr "Liste des gestes"
 
-#: addon\globalPlugins\brailleExtender\settings.py:806
+#: addon\globalPlugins\brailleExtender\settings.py:817
 msgid "Add gesture"
 msgstr "Ajouter un geste"
 
-#: addon\globalPlugins\brailleExtender\settings.py:808
+#: addon\globalPlugins\brailleExtender\settings.py:819
 msgid "Remove this gesture"
 msgstr "Supprimer ce geste"
 
-#: addon\globalPlugins\brailleExtender\settings.py:811
+#: addon\globalPlugins\brailleExtender\settings.py:822
 msgid "Assign a braille gesture"
 msgstr "Assigner un geste braille"
 
-#: addon\globalPlugins\brailleExtender\settings.py:818
+#: addon\globalPlugins\brailleExtender\settings.py:829
 msgid "Remove this profile"
 msgstr "Supprimer ce profil"
 
-#: addon\globalPlugins\brailleExtender\settings.py:821
+#: addon\globalPlugins\brailleExtender\settings.py:832
 msgid "Add a profile"
 msgstr "Ajouter un profil"
 
-#: addon\globalPlugins\brailleExtender\settings.py:827
+#: addon\globalPlugins\brailleExtender\settings.py:838
 msgid "Name for the new profile"
 msgstr "Nom pour le nouveau profil"
 
-#: addon\globalPlugins\brailleExtender\settings.py:833
+#: addon\globalPlugins\brailleExtender\settings.py:844
 msgid "Create"
 msgstr "Créer"
 
-#: addon\globalPlugins\brailleExtender\settings.py:893
+#: addon\globalPlugins\brailleExtender\settings.py:904
 msgid "Unable to load this profile. Malformed or inaccessible file"
 msgstr "Impossible de charger ce profil. Fichier invalide ou inaccessible"
 
-#: addon\globalPlugins\brailleExtender\settings.py:911
+#: addon\globalPlugins\brailleExtender\settings.py:922
 msgid "Undefined"
 msgstr "Indéfini"
 
-#: addon\globalPlugins\brailleExtender\updateCheck.py:39
+#: addon\globalPlugins\brailleExtender\updateCheck.py:51
 #, python-format
 msgid "New version available, version %s. Do you want download it now?"
 msgstr ""
 "Nouvelle version disponible, version %s. Voulez-vous la télécharger "
 "maintenant ?"
 
-#: addon\globalPlugins\brailleExtender\updateCheck.py:46
+#: addon\globalPlugins\brailleExtender\updateCheck.py:58
 #, python-format
 msgid "You are up-to-date. %s is the latest version."
 msgstr "Vous êtes à jour, %s est la dernière version."
 
-#: addon\globalPlugins\brailleExtender\updateCheck.py:52
+#: addon\globalPlugins\brailleExtender\updateCheck.py:64
 #, python-format
 msgid ""
 "Oops! There was a problem checking for updates. Please retry later or "
@@ -1569,26 +1571,29 @@ msgstr ""
 "Veuillez réessayer ultérieurement ou télécharger et installer manuellement "
 "via %s. Voulez-vous ouvrir cette URL dans votre navigateur maintenant ?"
 
-#: addon\globalPlugins\brailleExtender\updateCheck.py:81
+#: addon\globalPlugins\brailleExtender\updateCheck.py:93
 msgid "Unable to save or download update file. Opening your browser"
 msgstr ""
 "Impossible d’enregistrer ou de télécharger le fichier de mise à jour. "
 "Ouverture de votre navigateur"
 
-#: addon\globalPlugins\brailleExtender\updateCheck.py:85
+#: addon\globalPlugins\brailleExtender\updateCheck.py:97
 msgid "BrailleExtender's Update"
 msgstr "Mise à jour de BrailleExtender"
 
-#: addon\globalPlugins\brailleExtender\utils.py:188
+#: addon\globalPlugins\brailleExtender\utils.py:191
 msgid "Reload successful"
 msgstr "Rechargement réussi"
 
-#: addon\globalPlugins\brailleExtender\utils.py:191
+#: addon\globalPlugins\brailleExtender\utils.py:194
 msgid "Reload failed"
 msgstr "Rechargement échoué"
 
-#: addon\globalPlugins\brailleExtender\utils.py:206
-msgid "Not a character."
+#: addon\globalPlugins\brailleExtender\utils.py:199
+#: addon\globalPlugins\brailleExtender\utils.py:207
+#, fuzzy
+#| msgid "Not a character."
+msgid "Not a character"
 msgstr "Ce n’est pas un caractère."
 
 #: addon\globalPlugins\brailleExtender\utils.py:330
@@ -1651,7 +1656,7 @@ msgstr ""
 #: buildVars.py:23
 msgid "reload two favorite braille display with shortcuts"
 msgstr ""
-"de basculer entre deux afficheurs braille favoris ou encore de les recharger "
+"basculer entre deux afficheurs braille favoris ou encore de les recharger "
 "aisément"
 
 #: buildVars.py:24
@@ -1750,6 +1755,9 @@ msgstr "de lancer rapidement des applications"
 #: buildVars.py:41
 msgid "actions and quick navigation through a rotor"
 msgstr "actions et navigation rapide au travers d’un rotor"
+
+#~ msgid "testing"
+#~ msgstr "test"
 
 #~ msgid "Location"
 #~ msgstr "Emplacement"

--- a/buildVars.py
+++ b/buildVars.py
@@ -10,15 +10,15 @@ _ = lambda x : x
 # Add-on information variables
 addon_info = {
 	# for previously unpublished addons, please follow the community guidelines at:
-	# https://bitbucket.org/nvdaaddonteam/todo/raw/master/guideLines.txt
+	# https://bitbucket.org/nvdaaddonteam/todo/raw/master/guidelines.txt
 	# add-on Name, internal for nvda
-	"addon_name" : "BrailleExtender",
+	"addon_name": "BrailleExtender",
 	# Add-on summary, usually the user visible name of the addon.
 	# Translators: Summary for this add-on to be shown on installation and add-on information.
-	"addon_summary" : _("Braille Extender"),
+	"addon_summary": _("Braille Extender"),
 	# Add-on description
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
-	"addon_description" : [
+	"addon_description": [
 	_("BrailleExtender is a NVDA add-on that provides various features at braille level. Currently, the following features are implemented"), ":",
 	"\n* ", _("reload two favorite braille display with shortcuts"), ";",
 	"\n* ", _("automatic review cursor tethering in terminal role like in PuTTY, Powershell, bash, cmd"), ";",
@@ -39,21 +39,21 @@ addon_info = {
 	"\n* ", _("offer several keyboard configurations concerning the possibility to input dots 7 and 8, enter and backspace"), ";",
 	"\n* ", _("launch an application quickly"), ";",
 	"\n* ", _("actions and quick navigation through a rotor"), "."
-],
+	],
 	# version
-	"addon_version" : time.strftime('%y.%m.%d-%H%M%S'),
+	"addon_version": "dev_py3-"+time.strftime("%y.%m.%d-%H%M%S"),
 	# Author(s)
-	"addon_author" : u"André-Abush Clause <dev@andreabc.net>",
+	"addon_author": "André-Abush Clause <dev@andreabc.net>",
 	# URL for the add-on documentation support
-	"addon_url" : "https://andreabc.net/projects/NVDA_addons/BrailleExtender/",
+	"addon_url": "https://andreabc.net/projects/NVDA_addons/BrailleExtender/",
 	# Documentation file name
-	"addon_docFileName" : None,
-	# Minimum NVDA version supported (e.g. "2018.3")
-	"addon_minimumNVDAVersion" : "2018.3.0",
-	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2019.4.0",
+	"addon_docFileName": "readme.html",
+	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
+	"addon_minimumNVDAVersion": "2018.3",
+	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
+	"addon_lastTestedNVDAVersion": "2019.3",
 	# Add-on update channel (default is stable or None)
-	"addon_updateChannel" : None,
+	"addon_updateChannel": None,
 }
 
 
@@ -61,8 +61,7 @@ import os.path
 
 # Define the python files that are the sources of your add-on.
 # You can use glob expressions here, they will be expanded.
-pythonSources = [os.path.join("addon", "*.py"),
-os.path.join("addon", "globalPlugins", "brailleExtender", "*.py")]
+pythonSources = []
 
 # Files that contain strings for translation. Usually your python sources
 i18nSources = pythonSources + ["buildVars.py"]

--- a/buildVars.py
+++ b/buildVars.py
@@ -61,7 +61,9 @@ import os.path
 
 # Define the python files that are the sources of your add-on.
 # You can use glob expressions here, they will be expanded.
-pythonSources = []
+pythonSources = [os.path.join("addon", "*.py"),
+os.path.join("addon", "globalPlugins", "brailleExtender", "*.py")]
+
 
 # Files that contain strings for translation. Usually your python sources
 i18nSources = pythonSources + ["buildVars.py"]

--- a/sconstruct
+++ b/sconstruct
@@ -21,7 +21,7 @@ def md2html(source, dest):
 	}
 	with codecs.open(source, "r", "utf-8") as f:
 		mdText = f.read()
-		for k, v in headerDic.iteritems():
+		for k, v in headerDic.items():
 			mdText = mdText.replace(k, v, 1)
 		htmlText = markdown.markdown(mdText)
 	with codecs.open(dest, "w", "utf-8") as f:
@@ -128,7 +128,12 @@ def generateManifest(source, dest):
 		f.write(manifest)
 
 def generateTranslatedManifest(source, language, out):
-	_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[language]).ugettext
+	# No ugettext in Python 3.
+	import sys
+	if sys.version_info.major == 2:
+		_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[language]).ugettext
+	else:
+		_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[language]).gettext
 	vars = {}
 	for var in ("addon_summary", "addon_description"):
 		if isinstance(buildVars.addon_info[var], str):
@@ -174,7 +179,7 @@ for mdFile in env.Glob(os.path.join('addon', 'doc', '*', '*.md')):
 # Pot target
 i18nFiles = expandGlobs(buildVars.i18nSources)
 gettextvars={
-		'gettext_package_bugs_address' : 'nvda-translations@freelists.org',
+		'gettext_package_bugs_address' : 'nvda-translations@groups.io',
 		'gettext_package_name' : buildVars.addon_info['addon_name'],
 		'gettext_package_version' : buildVars.addon_info['addon_version']
 	}


### PR DESCRIPTION
Some features are temporarily unavailable. Overview of current status and future availability (checked = feature already compatible, not checked = will be Restored soon):

- [x] Reload two favorite braille display with shortcuts
- [x] Automatic review cursor tethering in terminal role like in PuTTY, Powershell, bash, cmd
- [x] Auto scroll
- [x] Switch between several input/output braille tables
- [x] Mark the text with special attributes through dot 7, dot 8 or both
- [x] Translate text easily in Unicode braille and vice versa. E.g.: u <-> ⠥
- [x] Convert quickly cell description to Unicode braille and vice versa. E.g.: 123 <--> ⠇
- [x] Quick launches
- [x] Gesture maps
- [x] Save/show a braille view
- [x] Information on current char (decimal, hexadecimal, octal and binary values)
- [x] Display the speech output in braille of a text selection
- [x] Display the documentation
- [x] Automatic update check
- [x] Settings
- [x] Say the current line during text scrolling either in review mode, or in focus mode or both
- [x] (Don't) interrupt speech when scrolling on same line
- [x] (Don't) interrupt speech for unknown gestures
- [x] Announce the character while moving with routing buttons
- [x] Lock braille keyboard
- [x] Reverse forward scroll and back scroll buttons
- [x] BRF mode
- [x] Hide/show dots 7 and 8
- [x] Use two output braille tables simultaneously
- [x] Display tab signs as spaces
- [x] Custom role labels
- [ ] Ensure Python 2 compatibility

[Download latest release (NVDA 2019.3 only)](https://andreabc.net/projects/NVDA_addons/BrailleExtender/latest?py3=1)