### PR TITLE
Python 3 porting: remove isPy3 check varaible

### DIFF
--- a/addon/globalPlugins/brailleExtender/__init__.py
+++ b/addon/globalPlugins/brailleExtender/__init__.py
@@ -7,7 +7,7 @@
 # Additional third party copyrighted code is included:
 #  - *Attribra*: Copyright (C) 2017 Alberto Zanella <lapostadialberto@gmail.com>
 #  -> https://github.com/albzan/attribra/
-from __future__ import unicode_literals
+
 from collections import OrderedDict
 from logHandler import log
 

--- a/addon/globalPlugins/brailleExtender/__init__.py
+++ b/addon/globalPlugins/brailleExtender/__init__.py
@@ -14,7 +14,6 @@ from logHandler import log
 import os
 import re
 import subprocess
-import sys
 import time
 import urllib
 import gui
@@ -194,7 +193,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		if config.conf["brailleExtender"]["lastNVDAVersion"] != updateCheck.versionInfo.version:
 			config.conf["brailleExtender"]["lastNVDAVersion"] = updateCheck.versionInfo.version
 			checkingForced = True
-		delayChecking = 86400 if isPy3 or config.conf["brailleExtender"]["updateChannel"] != configBE.CHANNEL_stable else 604800
+		delayChecking = 86400 if config.conf["brailleExtender"]["updateChannel"] != configBE.CHANNEL_stable else 604800
 		if not globalVars.appArgs.secure and config.conf["brailleExtender"]["autoCheckUpdate"] and (checkingForced or (time.time() - config.conf["brailleExtender"]["lastCheckUpdate"]) > delayChecking):
 			checkUpdates(True)
 			config.conf["brailleExtender"]["lastCheckUpdate"] = time.time()
@@ -311,9 +310,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		dictionaries.notifyInvalidTables()
 		if config.conf["brailleExtender"]["tabSpace"]:
 			liblouisDef = r"always \t " + ("0-" * configBE.getTabSize()).strip('-')
-			if isPy3:
-				patchs.louis.compileString(patchs.getCurrentBrailleTables(), bytes(liblouisDef, "ASCII"))
-			else: patchs.louis.compileString(patchs.getCurrentBrailleTables(), bytes(liblouisDef))
+			patchs.louis.compileString(patchs.getCurrentBrailleTables(), bytes(liblouisDef, "ASCII"))
 		undefinedChars.setUndefinedChar()
 
 	@staticmethod

--- a/addon/globalPlugins/brailleExtender/addonDoc.py
+++ b/addon/globalPlugins/brailleExtender/addonDoc.py
@@ -3,7 +3,6 @@
 # Part of BrailleExtender addon for NVDA
 # Copyright 2016-2020 André-Abush CLAUSE, released under GPL.
 
-from __future__ import unicode_literals
 import re
 import addonHandler
 

--- a/addon/globalPlugins/brailleExtender/common.py
+++ b/addon/globalPlugins/brailleExtender/common.py
@@ -5,7 +5,6 @@
 
 from __future__ import unicode_literals
 import os
-import sys
 import struct
 
 import addonHandler
@@ -13,10 +12,8 @@ import globalVars
 import languageHandler
 from logHandler import log
 
-isPy3 = sys.version_info >= (3, 0)
 configDir = "%s/brailleExtender" % globalVars.appArgs.configPath
 baseDir = os.path.dirname(__file__)
-if not isPy3: baseDir = baseDir.decode("mbcs")
 addonDir = os.path.join(baseDir, "..", "..")
 addonName = addonHandler.Addon(addonDir).manifest["name"]
 addonSummary = addonHandler.Addon(addonDir).manifest["summary"]
@@ -32,9 +29,3 @@ punctuationSeparator = ' ' if 'fr' in lang else ''
 
 
 profilesDir = os.path.join(baseDir, "Profiles")
-if not isPy3:
-	def chrPy2(i):
-		try: return unichr(i)
-		except ValueError: return struct.pack('i', i).decode('utf-32')
-
-	chr = chrPy2

--- a/addon/globalPlugins/brailleExtender/common.py
+++ b/addon/globalPlugins/brailleExtender/common.py
@@ -3,7 +3,6 @@
 # Part of BrailleExtender addon for NVDA
 # Copyright 2016-2020 André-Abush CLAUSE, released under GPL.
 
-from __future__ import unicode_literals
 import os
 import struct
 

--- a/addon/globalPlugins/brailleExtender/configBE.py
+++ b/addon/globalPlugins/brailleExtender/configBE.py
@@ -3,7 +3,6 @@
 # Part of BrailleExtender addon for NVDA
 # Copyright 2016-2020 André-Abush CLAUSE, released under GPL.
 
-from __future__ import unicode_literals
 import os
 import globalVars
 from collections import OrderedDict

--- a/addon/globalPlugins/brailleExtender/dictionaries.py
+++ b/addon/globalPlugins/brailleExtender/dictionaries.py
@@ -2,7 +2,7 @@
 # dictionaries.py
 # Part of BrailleExtender addon for NVDA
 # Copyright 2016-2020 André-Abush CLAUSE, released under GPL.
-from __future__ import unicode_literals
+
 import gui
 import wx
 import os.path

--- a/addon/globalPlugins/brailleExtender/patchs.py
+++ b/addon/globalPlugins/brailleExtender/patchs.py
@@ -4,7 +4,6 @@
 # Copyright 2016-2020 André-Abush CLAUSE, released under GPL.
 # This file modify some functions from core.
 
-from __future__ import unicode_literals
 import os
 import re
 import sys

--- a/addon/globalPlugins/brailleExtender/settings.py
+++ b/addon/globalPlugins/brailleExtender/settings.py
@@ -3,7 +3,6 @@
 # Part of BrailleExtender addon for NVDA
 # Copyright 2016-2020 André-Abush CLAUSE, released under GPL.
 
-from __future__ import unicode_literals
 import glob
 import hashlib
 import os

--- a/addon/globalPlugins/brailleExtender/updateCheck.py
+++ b/addon/globalPlugins/brailleExtender/updateCheck.py
@@ -2,7 +2,7 @@
 # updateCheck.py
 # Part of BrailleExtender addon for NVDA
 # Copyright 2020 André-Abush Clause, released under GPL.
-from __future__ import unicode_literals
+
 from logHandler import log
 import json
 import os

--- a/addon/globalPlugins/brailleExtender/updateCheck.py
+++ b/addon/globalPlugins/brailleExtender/updateCheck.py
@@ -6,15 +6,11 @@ from __future__ import unicode_literals
 from logHandler import log
 import json
 import os
-import sys
 import time
 import threading
 import tones
-isPy3 = sys.version_info >= (3, 0)
-if isPy3:
-	import urllib.parse
-	import urllib.request
-else: import urllib
+import urllib.parse
+import urllib.request
 
 import gui
 import wx
@@ -31,7 +27,6 @@ import versionInfo
 addonHandler.initTranslation()
 
 baseDir = os.path.dirname(__file__)
-if not isPy3: baseDir = baseDir.decode("mbcs")
 _addonDir = os.path.join(baseDir, "..", "..")
 addonInfos = addonHandler.Addon(_addonDir).manifest
 sectionName = "brailleExtender"
@@ -46,9 +41,9 @@ def paramsDL(): return {
 	"brailledisplay": braille.handler.display.name,
 }
 
-urlencode = urllib.parse.urlencode if isPy3 else urllib.urlencode
-URLopener = urllib.request.URLopener if isPy3 else urllib.URLopener
-urlopen = urllib.request.urlopen if isPy3 else urllib.urlopen
+urlencode = urllib.parse.urlencode
+URLopener = urllib.request.URLopener
+urlopen = urllib.request.urlopen
 
 def checkUpdates(sil = False):
 

--- a/addon/globalPlugins/brailleExtender/utils.py
+++ b/addon/globalPlugins/brailleExtender/utils.py
@@ -440,7 +440,7 @@ def getTether():
 
 
 def getCharFromValue(s):
-	if not isinstance(s, str if isPy3 else (str, unicode)): raise TypeError("Wrong type")
+	if not isinstance(s, str): raise TypeError("Wrong type")
 	if not s or len(s) < 2: raise ValueError("Wrong value")
 	supportedBases = {'b': 2, 'd': 10, 'h': 16, 'o': 8, 'x': 16}
 	base, n = s[0].lower(), s[1:]

--- a/addon/globalPlugins/brailleExtender/utils.py
+++ b/addon/globalPlugins/brailleExtender/utils.py
@@ -3,7 +3,6 @@
 # Part of BrailleExtender addon for NVDA
 # Copyright 2016-2020 André-Abush CLAUSE, released under GPL.
 
-from __future__ import unicode_literals
 import os.path as osp
 import re
 import api


### PR DESCRIPTION
Hi Andre,

This pull request removes check for isPy3 variable. This was done because the add-on manifest says Braille Extender supports NVDA 2019.3, which is a Python 3 release, along with the fact that NVDA Core wants Python 3.7 or later. As a result, conditions that formerly required checking for Python 3 has been lifted tyhrough this PR, including imports, urllib module contents in update checks and others. Also, the PR removes the line "from __future__ import unicode_literals" as Unicode is used in Python 3 natively.

Thanks.