### PR TITLE
Preliminary compatibility with NVDA 2022.1

### DIFF
--- a/addon/globalPlugins/brailleExtender/__init__.py
+++ b/addon/globalPlugins/brailleExtender/__init__.py
@@ -18,7 +18,6 @@ import braille
 import brailleInput
 import brailleTables
 import config
-import controlTypes
 import globalCommands
 import globalPluginHandler
 import globalVars
@@ -213,7 +212,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			self.bindRotorGES()
 
 		if config.conf["brailleExtender"]["reviewModeTerminal"]:
-			if not self.switchedMode and obj.role == controlTypes.ROLE_TERMINAL and obj.hasFocus:
+			if not self.switchedMode and obj.role == utils.get_control_type("ROLE_TERMINAL") and obj.hasFocus:
 				if not hasattr(braille.handler, "TETHER_AUTO"):
 					self.backupTether = utils.getTether()
 					braille.handler.tether = braille.handler.TETHER_REVIEW
@@ -226,7 +225,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 					braille.handler.setTether(braille.handler.TETHER_REVIEW, auto=False)
 					braille.handler.handleReviewMove(shouldAutoTether=False)
 				self.switchedMode = True
-			elif self.switchedMode and obj.role != controlTypes.ROLE_TERMINAL: self.restorReviewCursorTethering()
+			elif self.switchedMode and obj.role != utils.get_control_type("ROLE_TERMINAL"): self.restorReviewCursorTethering()
 
 		if "tabSize_%s" % addoncfg.curBD not in config.conf["brailleExtender"].copy().keys(): self.onReload(None, 1)
 		if self.hourDatePlayed: self.script_hourDate(None)

--- a/addon/globalPlugins/brailleExtender/patches.py
+++ b/addon/globalPlugins/brailleExtender/patches.py
@@ -13,7 +13,6 @@ import api
 import braille
 import brailleInput
 import config
-import controlTypes
 import core
 import globalCommands
 import inputCore
@@ -43,7 +42,7 @@ from . import regionhelper
 from . import undefinedchars
 from .common import baseDir, RC_EMULATE_ARROWS_BEEP, RC_EMULATE_ARROWS_SILENT
 from .onehand import process as processOneHandMode
-from .utils import getCurrentChar, getSpeechSymbols, getTether, getCharFromValue, getCurrentBrailleTables, get_output_reason
+from .utils import getCurrentChar, getSpeechSymbols, getTether, getCharFromValue, getCurrentBrailleTables, get_output_reason, get_control_type
 
 addonHandler.initTranslation()
 
@@ -96,7 +95,7 @@ def script_braille_routeTo(self, gesture):
 		braille.handler.buffer is braille.handler.mainBuffer and
 		braille.handler.mainBuffer.cursorPos is not None and
 		obj.hasFocus and
-		obj.role in [controlTypes.ROLE_TERMINAL, controlTypes.ROLE_EDITABLETEXT]	
+		obj.role in [get_control_type("ROLE_TERMINAL"), get_control_type("ROLE_EDITABLETEXT")]
 	):
 		play_beeps = config.conf["brailleExtender"]["routingCursorsEditFields"] == RC_EMULATE_ARROWS_BEEP
 		nb = 0
@@ -162,7 +161,7 @@ def update(self):
 		}
 		if config.conf["brailleExtender"]["attributes"]["selectedElement"] in d:
 			addDots = d[config.conf["brailleExtender"]["attributes"]["selectedElement"]]
-			if hasattr(self, "obj") and self.obj and hasattr(self.obj, "states") and self.obj.states and self.obj.name and controlTypes.STATE_SELECTED in self.obj.states:
+			if hasattr(self, "obj") and self.obj and hasattr(self.obj, "states") and self.obj.states and self.obj.name and get_control_type("STATE_SELECTED") in self.obj.states:
 				name = self.obj.name
 				if name in self.rawText:
 					start = self.rawText.index(name)

--- a/addon/globalPlugins/brailleExtender/undefinedchars.py
+++ b/addon/globalPlugins/brailleExtender/undefinedchars.py
@@ -15,7 +15,7 @@ from logHandler import log
 from . import addoncfg
 from . import huc
 from . import regionhelper
-from .utils import getCurrentBrailleTables, getTextInBraille
+from .utils import getCurrentBrailleTables, getTextInBraille, get_symbol_level
 
 addonHandler.initTranslation()
 
@@ -113,7 +113,7 @@ def getDescChar(c, lang="Windows", start="", end=""):
 	if lang == "Windows":
 		lang = languageHandler.getLanguage()
 	desc = characterProcessing.processSpeechSymbols(
-		lang, c, characterProcessing.SYMLVL_CHAR).replace(' ', '').strip()
+		lang, c, get_symbol_level("SYMLVL_CHAR")).strip()
 	if not desc or desc == c:
 		return getAlternativeDescChar(c, method)
 	return f"{start}{desc}{end}"

--- a/addon/globalPlugins/brailleExtender/utils.py
+++ b/addon/globalPlugins/brailleExtender/utils.py
@@ -288,7 +288,7 @@ def getSpeechSymbols(text = None):
 	if not text: text = getTextSelection()
 	if not text: return ui.message(_("No text selected"))
 	locale = languageHandler.getLanguage()
-	return characterProcessing.processSpeechSymbols(locale, text, characterProcessing.SYMLVL_CHAR).strip()
+	return characterProcessing.processSpeechSymbols(locale, text, get_symbol_level("SYMLVL_CHAR")).strip()
 
 def getTether():
 	if hasattr(braille.handler, "getTether"):
@@ -357,3 +357,25 @@ def set_speech_talk():
 	if hasattr(speech, "SpeechMode"):
 		return speech.setSpeechMode(speech.SpeechMode.talk)
 	speech.speechMode = speech.speechMode_talk
+
+newControlTypes = hasattr(controlTypes, "Role")
+def get_control_type(control_type):
+	if not isinstance(control_type, str):
+		raise TypeError()
+	if newControlTypes:
+		attr = '_'.join(control_type.split('_')[1:])
+		if control_type.startswith("ROLE_"):
+			return getattr(controlTypes.Role, attr)
+		elif control_type.startswith("STATE_"):
+			return getattr(controlTypes.State, attr)
+		else:
+			raise ValueError(control_type)
+	return getattr(controlTypes, control_type)
+
+newSymbolLevel = hasattr(characterProcessing, "SymbolLevel")
+def get_symbol_level(symbol_level):
+	if not isinstance(symbol_level, str):
+		raise TypeError()
+	if newSymbolLevel:
+		return getattr(characterProcessing.SymbolLevel, '_'.join(symbol_level.split('_')[1:]))
+	return getattr(characterProcessing, symbol_level)


### PR DESCRIPTION
See https://github.com/nvaccess/nvda/issues/12510, https://github.com/nvaccess/nvda/issues/11856 and https://github.com/nvaccess/nvda/issues/12636

According to the NVDA change log:

> - `characterProcessing.SYMLVL_*` constants should be replaced using their equivalent `SymbolLevel.*` before 2022.1.
> - controlTypes has been split up into various submodules, symbols marked for deprecation must be replaced before 2022.1.
