### PR TITLE
Add Excel braille settings: formulas in braille, row/column cell scope, and routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ These match the tabs in **Braille Extender settings**:
 | **Auto scroll** | Delays and behavior for automatic braille scrolling. |
 | **Speech History Mode** | History length, numbering, optional speech while browsing history. |
 | **Document formatting** | How formatting (bold, links, alignment, …) appears in braille, on top of NVDA’s document formatting (see [Detailed topics](#document-formatting)). |
+| **Excel** | Show cell values and formulas in braille; optional row or column overview with routing (see [Excel](#excel)). |
 | **Object Presentation** | Order of name, state, value, and other fields on the focus line; highlight selection with dots 7/8; progress bar messages on the display. |
 | **Braille tables** | Preferred input/output table lists, optional automatic tables on NVDA 2025.1+, shortcut input table, second translation pass, tabs as spaces, **Manage custom braille tables…** (NVDA 2024.3+). |
 | **Undefined character representation** | How characters missing from the table appear (dots, numbers, descriptions, HUC, …). |
@@ -207,7 +208,6 @@ Braille Extender does **not** replace NVDA’s **Document formatting** dialog. T
 - **Plain text mode** — disable all text formatting from this layer.
 - **Process formatting line per line** — build braille one line at a time.
 - **Report rows** — one combo per category (font attributes, emphasis, alignment, colors, links, headings, lists, tables, cell coordinates, spelling/grammar, and others listed on the tab).
-- **Cell formula (Excel only for now)** — when enabled, move a cell’s formula into the description field for braille when applicable.
 - **Level of items in a nested list** — show list nesting level in braille.
 - **Methods…** — per-attribute display (nothing, hand over to the table, dots 7/8, tags, line padding for alignments, etc.).
 - **Tags…** — start/end tag strings used by tag-style methods.
@@ -238,8 +238,6 @@ You can reorder these fields (labels match the dialog):
 
 - **Description**, **keyboard shortcut**, and **position** only appear if the matching options are enabled in NVDA **Settings → Object presentation**.
 - **Cell coordinates** also follow **Braille Extender → Document formatting → Cell coordinates**.
-
-**Excel:** with **Document formatting → Cell formula (Excel only for now)** enabled, a cell’s formula may appear in the description area instead of crowding the state line.
 
 Row and column headers from the application may still be added after the main summary when available.
 
@@ -274,6 +272,82 @@ The three choices (**Follow NVDA document formatting**, **enabled**, **disabled*
 | **Follow NVDA document formatting** | Follows NVDA **Report background progress bars**, or shows bars in the window you are working in |
 | **enabled** | Progress bars in background and foreground windows |
 | **disabled** | Only progress bars in the **foreground** window |
+
+### Excel
+
+Open **Braille Extender settings → Excel** to control how **Microsoft Excel** worksheet cells appear in braille. These options are for the **desktop Excel** program when NVDA can read cells on the sheet the same way it does when you move around with the arrow keys. They do **not** apply to other spreadsheet programs (for example LibreOffice Calc or sheets in a web browser).
+
+If you previously used **Document formatting → Cell formula**, that option has moved here. When you update the add-on, your previous on/off choice is copied into **Excel → Report cell formulas in braille** automatically.
+
+#### Report cell formulas in braille
+
+When this box is **checked** (default), the add-on can show **formulas** on the braille display, not only the value you see in the cell. When it is **unchecked**, Excel cells behave like standard NVDA braille with no formula line from this add-on.
+
+Without the add-on, NVDA often shows a short **frml** hint when a cell has a formula. With **current cell only** scope (below), you still get the normal cell line (value, coordinates, and so on), and the **full formula** is added after that—so you read the formula itself instead of only **frml**.
+
+#### Formula scope
+
+Choose how much of the sheet appears on the braille display:
+
+| Choice | What you see |
+|--------|----------------|
+| **Current cell only** (default) | The focused cell as usual, plus its formula when the cell has one. Same layout as normal NVDA braille for that cell. |
+| **Current row** | A single line for the **row** you are in, from the first used cell to the last used cell in the range (see below). |
+| **Current column** | The same idea for the **column** you are in. |
+
+Row and column modes are meant for skimming **neighboring cells** without moving focus cell by cell.
+
+You can also change scope from the keyboard while Excel is running: in **NVDA → Preferences → Input gestures**, assign **Cycle how Microsoft Excel cell formulas are shown in braille (current cell, row, or column)** (listed under **Braille Extender**). There is no default shortcut; each press moves through **current cell only**, **current row**, then **current column**, and back to the start. The gesture only works when **Report cell formulas in braille** is enabled.
+
+In **current cell only** mode, braille panning behaves like normal NVDA (your place on the line is kept when you move between cells). In **current row** or **current column** mode, the **focused cell** is kept at the **left** of the braille display when you move to another cell, so the overview line stays aligned.
+
+#### Show formulas in row/column scope
+
+This list applies only when **Formula scope** is **Current row** or **Current column**:
+
+| Choice | Meaning |
+|--------|---------|
+| **Active cell only** (default) | Neighbors show their **values** only; the **focused** cell can still show its formula in its part of the line. |
+| **All cells in range** | Values **and** formulas for every cell shown on that line. |
+| **Values only (hide formulas)** | Every cell on the line shows only its value; formulas are hidden on that overview. |
+
+#### Number of cells before and after
+
+When you use **Current row** or **Current column**, this number sets how many cells **to the left and right** (on a row) or **above and below** (in a column) may be included. Default is **9** (up to **19** cells on the line: 9 + your cell + 9). You can set **0** to **50**.
+
+The line is **not** always the full width. It starts at the **first cell in that direction that has something in it** (or is your current cell) and ends at the **last** such cell. Empty cells **between** two cells that have content are included as blank gaps on the line.
+
+#### Cell separator
+
+Text placed **between** each cell on a row or column line. Default is a space, vertical bar, space: ` | `. You can change it (for example to ` - ` or `, `) to suit your reading style.
+
+#### How a row or column line looks
+
+Examples (default separator):
+
+- Row **2**, you are in **A2** with value `Hello`, empty **B2–F2**, value `99` in **G2**:  
+  `r2 A2: Hello |  |  |  |  |  | 99`
+- The **`r2`** or **`cD`** prefix reminds you which row or column the line belongs to.
+- Only the **current** cell uses its address in the line (for example `A2: Hello`). Other cells show only their value (or nothing if empty).
+- **Empty** cells between two cells with content appear as separator with nothing between (for example ` |  | `).
+- **Row and column headers** you have set up in the workbook (the extra labels NVDA can announce for the current cell) are shown after the **current** cell’s part of the line, not after every neighbor.
+
+#### Routing keys on a row or column line
+
+When **Formula scope** is **Current row** or **Current column**, each part of the line is tied to **one cell**:
+
+- Press a **routing key** on the **current** cell’s value (for example under `Hello` in `A2: Hello`) to **edit** that cell, like routing on a normal Excel cell in NVDA.
+- Press a routing key on a **neighbor’s** value (or on an empty gap for an empty cell) to **move** to that cell.
+
+So you can jump along the row or column from the braille display without arrowing through every cell.
+
+#### Merged cells
+
+If several columns or rows are **merged** into one cell:
+
+- The **value** is shown **once** at the start of the merged area on the line (not repeated in every column or row of the merge).
+- Other positions covered by the merge appear as **empty** slots on the line, but routing there still takes you to that **merged** cell.
+- The **current** cell shows the full merged address when NVDA reports it that way (for example `B2 through D2`), and you still see its value or formula when you are anywhere in that merge.
 
 ### Undefined character representation
 

--- a/README.md
+++ b/README.md
@@ -292,18 +292,18 @@ This setting controls **how much of the sheet** appears on the braille display a
 | Choice | What you see |
 |--------|----------------|
 | **Focused cell only** (default) | The cell you are in, as usual, plus its formula when the cell has one. Same layout as normal NVDA braille for that cell. |
-| **Entire row on one line** | One braille line for the **row** you are in, from the first used cell to the last used cell in the range (see below). |
-| **Entire column on one line** | The same idea for the **column** you are in. |
+| **Row range on one line** | A **portion of the row** around your cell on one braille line—not the full worksheet row. How many cells each side is set under **Cells on each side of focus** (default **9**). The line may be shorter: only from the first to the last **non-empty** cell in that window. |
+| **Column range on one line** | The same for the **column** around your cell (again a limited range, not the whole column). |
 
-Row and column views are meant for skimming **neighboring cells** without moving focus cell by cell.
+Row and column range views are meant for skimming **nearby cells** without moving focus cell by cell.
 
-You can also change **Braille view** from the keyboard while Excel is running: in **NVDA → Preferences → Input gestures**, assign **Cycle Excel braille view (focused cell, entire row, or entire column on one line)** (listed under **Braille Extender**). There is no default shortcut; each press moves through **Focused cell only**, **Entire row on one line**, then **Entire column on one line**, and back to the start. The gesture only works when **Report cell formulas in braille** is enabled.
+You can also change **Braille view** from the keyboard while Excel is running: in **NVDA → Preferences → Input gestures**, assign **Cycle Excel braille view (focused cell, row range, or column range on one line)** (listed under **Braille Extender**). There is no default shortcut; each press moves through **Focused cell only**, **Row range on one line**, then **Column range on one line**, and back to the start. The gesture only works when **Report cell formulas in braille** is enabled.
 
-In **Focused cell only** view, braille panning behaves like normal NVDA (your place on the line is kept when you move between cells). In **Entire row on one line** or **Entire column on one line** view, the **focused cell** is kept at the **left** of the braille display when you move to another cell, so the overview line stays aligned.
+In **Focused cell only** view, braille panning behaves like normal NVDA (your place on the line is kept when you move between cells). In **Row range on one line** or **Column range on one line** view, the **focused cell** is kept at the **left** of the braille display when you move to another cell, so the overview line stays aligned.
 
 #### Formulas on row or column line
 
-This list applies only when **Braille view** is **Entire row on one line** or **Entire column on one line**:
+This list applies only when **Braille view** is **Row range on one line** or **Column range on one line**:
 
 | Choice | Meaning |
 |--------|---------|
@@ -313,9 +313,9 @@ This list applies only when **Braille view** is **Entire row on one line** or **
 
 #### Cells on each side of focus
 
-When **Braille view** is **Entire row on one line** or **Entire column on one line**, this number sets how many cells **to the left and right** (on a row) or **above and below** (in a column) may be included. Default is **9** (up to **19** cells on the line: 9 + your cell + 9). You can set **0** to **50**.
+When **Braille view** is **Row range on one line** or **Column range on one line**, this number is the maximum cells **to the left and right** of your cell (on a row) or **above and below** (in a column) that can appear on the line. Default is **9** (up to **19** positions: 9 + your cell + 9). You can set **0** to **50**.
 
-The line is **not** always the full width. It starts at the **first cell in that direction that has something in it** (or is your current cell) and ends at the **last** such cell. Empty cells **between** two cells that have content are included as blank gaps on the line.
+The line is usually **shorter** than that maximum: it runs from the first to the last **non-empty** cell in the window. Empty cells **between** two cells that have content still appear as blank gaps on the line.
 
 #### Separator between cells on the line
 
@@ -334,7 +334,7 @@ Examples (default separator):
 
 #### Routing keys on a row or column line
 
-When **Braille view** is **Entire row on one line** or **Entire column on one line**, each part of the line is tied to **one cell**:
+When **Braille view** is **Row range on one line** or **Column range on one line**, each part of the line is tied to **one cell**:
 
 - Press a **routing key** on the **current** cell’s value (for example under `Hello` in `A2: Hello`) to **edit** that cell, like routing on a normal Excel cell in NVDA.
 - Press a routing key on a **neighbor’s** value (or on an empty gap for an empty cell) to **move** to that cell.

--- a/README.md
+++ b/README.md
@@ -283,41 +283,41 @@ If you previously used **Document formatting → Cell formula**, that option has
 
 When this box is **checked** (default), the add-on can show **formulas** on the braille display, not only the value you see in the cell. When it is **unchecked**, Excel cells behave like standard NVDA braille with no formula line from this add-on.
 
-Without the add-on, NVDA often shows a short **frml** hint when a cell has a formula. With **current cell only** scope (below), you still get the normal cell line (value, coordinates, and so on), and the **full formula** is added after that—so you read the formula itself instead of only **frml**.
+Without the add-on, NVDA often shows a short **frml** hint when a cell has a formula. With **Focused cell only** (below), you still get the normal cell line (value, coordinates, and so on), and the **full formula** is added after that—so you read the formula itself instead of only **frml**.
 
-#### Formula scope
+#### Braille view
 
-Choose how much of the sheet appears on the braille display:
+This setting controls **how much of the sheet** appears on the braille display at once:
 
 | Choice | What you see |
 |--------|----------------|
-| **Current cell only** (default) | The focused cell as usual, plus its formula when the cell has one. Same layout as normal NVDA braille for that cell. |
-| **Current row** | A single line for the **row** you are in, from the first used cell to the last used cell in the range (see below). |
-| **Current column** | The same idea for the **column** you are in. |
+| **Focused cell only** (default) | The cell you are in, as usual, plus its formula when the cell has one. Same layout as normal NVDA braille for that cell. |
+| **Entire row on one line** | One braille line for the **row** you are in, from the first used cell to the last used cell in the range (see below). |
+| **Entire column on one line** | The same idea for the **column** you are in. |
 
-Row and column modes are meant for skimming **neighboring cells** without moving focus cell by cell.
+Row and column views are meant for skimming **neighboring cells** without moving focus cell by cell.
 
-You can also change scope from the keyboard while Excel is running: in **NVDA → Preferences → Input gestures**, assign **Cycle how Microsoft Excel cell formulas are shown in braille (current cell, row, or column)** (listed under **Braille Extender**). There is no default shortcut; each press moves through **current cell only**, **current row**, then **current column**, and back to the start. The gesture only works when **Report cell formulas in braille** is enabled.
+You can also change **Braille view** from the keyboard while Excel is running: in **NVDA → Preferences → Input gestures**, assign **Cycle Excel braille view (focused cell, entire row, or entire column on one line)** (listed under **Braille Extender**). There is no default shortcut; each press moves through **Focused cell only**, **Entire row on one line**, then **Entire column on one line**, and back to the start. The gesture only works when **Report cell formulas in braille** is enabled.
 
-In **current cell only** mode, braille panning behaves like normal NVDA (your place on the line is kept when you move between cells). In **current row** or **current column** mode, the **focused cell** is kept at the **left** of the braille display when you move to another cell, so the overview line stays aligned.
+In **Focused cell only** view, braille panning behaves like normal NVDA (your place on the line is kept when you move between cells). In **Entire row on one line** or **Entire column on one line** view, the **focused cell** is kept at the **left** of the braille display when you move to another cell, so the overview line stays aligned.
 
-#### Show formulas in row/column scope
+#### Formulas on row or column line
 
-This list applies only when **Formula scope** is **Current row** or **Current column**:
+This list applies only when **Braille view** is **Entire row on one line** or **Entire column on one line**:
 
 | Choice | Meaning |
 |--------|---------|
-| **Active cell only** (default) | Neighbors show their **values** only; the **focused** cell can still show its formula in its part of the line. |
-| **All cells in range** | Values **and** formulas for every cell shown on that line. |
-| **Values only (hide formulas)** | Every cell on the line shows only its value; formulas are hidden on that overview. |
+| **Focused cell only** (default) | Neighboring cells show their **values** only; the **focused** cell can still show its formula in its part of the line. |
+| **Every cell on the line** | Values **and** formulas for every cell shown on that line. |
+| **Values only (no formulas)** | Every cell on the line shows only its value; formulas are hidden on that overview. |
 
-#### Number of cells before and after
+#### Cells on each side of focus
 
-When you use **Current row** or **Current column**, this number sets how many cells **to the left and right** (on a row) or **above and below** (in a column) may be included. Default is **9** (up to **19** cells on the line: 9 + your cell + 9). You can set **0** to **50**.
+When **Braille view** is **Entire row on one line** or **Entire column on one line**, this number sets how many cells **to the left and right** (on a row) or **above and below** (in a column) may be included. Default is **9** (up to **19** cells on the line: 9 + your cell + 9). You can set **0** to **50**.
 
 The line is **not** always the full width. It starts at the **first cell in that direction that has something in it** (or is your current cell) and ends at the **last** such cell. Empty cells **between** two cells that have content are included as blank gaps on the line.
 
-#### Cell separator
+#### Separator between cells on the line
 
 Text placed **between** each cell on a row or column line. Default is a space, vertical bar, space: ` | `. You can change it (for example to ` - ` or `, `) to suit your reading style.
 
@@ -334,7 +334,7 @@ Examples (default separator):
 
 #### Routing keys on a row or column line
 
-When **Formula scope** is **Current row** or **Current column**, each part of the line is tied to **one cell**:
+When **Braille view** is **Entire row on one line** or **Entire column on one line**, each part of the line is tied to **one cell**:
 
 - Press a **routing key** on the **current** cell’s value (for example under `Hello` in `A2: Hello`) to **edit** that cell, like routing on a normal Excel cell in NVDA.
 - Press a routing key on a **neighbor’s** value (or on an empty gap for an empty cell) to **move** to that cell.

--- a/README.md
+++ b/README.md
@@ -321,13 +321,24 @@ The line is usually **shorter** than that maximum: it runs from the first to the
 
 Text placed **between** each cell on a row or column line. Default is a space, vertical bar, space: ` | `. You can change it (for example to ` - ` or `, `) to suit your reading style.
 
+#### Row and column line prefixes
+
+When **Braille view** is **Row range on one line** or **Column range on one line**, a short **prefix** is shown at the **start** of the braille line, **before** the current cell address. NVDA adds **one space** after the prefix automatically—do **not** put a trailing space in the setting.
+
+| Field | Default (English) | Role |
+|-------|-------------------|------|
+| **Row line prefix** | `row` | Row-range lines (example: `row A2: Hello | …`) |
+| **Column line prefix** | `col` | Column-range lines (example: `col A2: Hello | …`) |
+
+Leave a field **empty** to use the **translated** default for your NVDA language. Type your own short label (for example `R` or `Ln`) if you prefer something different on the display.
+
 #### How a row or column line looks
 
-Examples (default separator):
+Examples (default separator and prefixes):
 
 - Row **2**, you are in **A2** with value `Hello`, empty **B2–F2**, value `99` in **G2**:  
-  `r2 A2: Hello |  |  |  |  |  | 99`
-- The **`r2`** or **`cD`** prefix reminds you which row or column the line belongs to.
+  `row A2: Hello |  |  |  |  |  | 99`
+- The prefix (**`row`** or **`col`** by default, or your custom text) shows whether the line is a row range or a column range; the **current cell address** (`A2:`) comes immediately after that prefix and a single space.
 - Only the **current** cell uses its address in the line (for example `A2: Hello`). Other cells show only their value (or nothing if empty).
 - **Empty** cells between two cells with content appear as separator with nothing between (for example ` |  | `).
 - **Row and column headers** you have set up in the workbook (the extra labels NVDA can announce for the current cell) are shown after the **current** cell’s part of the line, not after every neighbor.

--- a/addon/appModules/brailleExtenderExcel.py
+++ b/addon/appModules/brailleExtenderExcel.py
@@ -62,9 +62,9 @@ class FormulaScope(StrEnum):
 
 
 SCOPE_LABELS: dict[FormulaScope, str] = {
-	FormulaScope.CELL: _("Current cell only"),
-	FormulaScope.ROW: _("Current row"),
-	FormulaScope.COLUMN: _("Current column"),
+	FormulaScope.CELL: _("Focused cell only"),
+	FormulaScope.ROW: _("Entire row on one line"),
+	FormulaScope.COLUMN: _("Entire column on one line"),
 }
 
 
@@ -986,9 +986,7 @@ class AppModule(_NVDAExcelAppModule):
 		_focus_excel_current_at_display_left(handler, handler.mainBuffer)
 
 	@script(
-		description=_(
-			"Cycle how Microsoft Excel cell formulas are shown in braille (current cell, row, or column)"
-		),
+		description=_("Cycle Excel braille view (focused cell, entire row, or entire column on one line)"),
 	)
 	def script_cycleExcelFormulaScope(self, gesture):
 		if not _conf()["cellFormula"]:

--- a/addon/appModules/brailleExtenderExcel.py
+++ b/addon/appModules/brailleExtenderExcel.py
@@ -63,8 +63,8 @@ class FormulaScope(StrEnum):
 
 SCOPE_LABELS: dict[FormulaScope, str] = {
 	FormulaScope.CELL: _("Focused cell only"),
-	FormulaScope.ROW: _("Entire row on one line"),
-	FormulaScope.COLUMN: _("Entire column on one line"),
+	FormulaScope.ROW: _("Row range on one line"),
+	FormulaScope.COLUMN: _("Column range on one line"),
 }
 
 
@@ -136,7 +136,7 @@ def _getScopedRangeWindow(
 	scope: FormulaScope | None = None,
 ) -> list[EXCEL_CELLINFO] | None:
 	scope = scope or _scope()
-	if not _conf()["cellFormula"] or not scope.isRowOrColumn:
+	if not scope.isRowOrColumn:
 		return None
 	settings_key = _scopedSettingsKey()
 	cache_key = id(obj)
@@ -279,7 +279,26 @@ def _currentCoords(obj: NVDAObject, cellInfo: EXCEL_CELLINFO | None) -> str | No
 			return obj.cellCoordsText
 	except (AttributeError, NotImplementedError):
 		pass
-	return _localAddress(cellInfo) if cellInfo else None
+	if cellInfo:
+		local = _localAddress(cellInfo)
+		if local:
+			return local
+		row = cellInfo.rowNumber
+		column = cellInfo.columnNumber
+		if row and column:
+			return f"{_columnLabel(column)}{row}"
+	try:
+		row = obj.rowNumber
+		column = obj.columnNumber
+		if row and column:
+			return f"{_columnLabel(column)}{row}"
+	except (AttributeError, NotImplementedError, TypeError):
+		pass
+	context = _getExcelCellContext(obj)
+	if context is not None:
+		_, row, column, _, _ = context
+		return f"{_columnLabel(column)}{row}"
+	return None
 
 
 def _cellContent(cellInfo: EXCEL_CELLINFO, *, isCurrent: bool) -> str:
@@ -287,17 +306,19 @@ def _cellContent(cellInfo: EXCEL_CELLINFO, *, isCurrent: bool) -> str:
 		return ""
 	formula = (cellInfo.formula or "").strip()
 	text = (cellInfo.text or "").strip()
-	if _isExcelFormula(formula) and _includeFormulaForCell(isCurrent):
+	if _isExcelFormula(formula) and _conf()["cellFormula"] and _includeFormulaForCell(isCurrent):
 		return f"{text} {formula}" if text else formula
 	return text
 
 
 def _hasDisplayContent(cellInfo: EXCEL_CELLINFO, *, isCurrent: bool) -> bool:
-	if not isCurrent and not _isPrimaryMergeCell(cellInfo):
+	if isCurrent:
+		return True
+	if not _isPrimaryMergeCell(cellInfo):
 		return False
 	if (cellInfo.text or "").strip():
 		return True
-	return _isExcelFormula(cellInfo.formula) and _includeFormulaForCell(isCurrent)
+	return _conf()["cellFormula"] and _isExcelFormula(cellInfo.formula) and _includeFormulaForCell(isCurrent)
 
 
 def _buildScopedWindow(
@@ -386,7 +407,8 @@ def _fetchScopedRangeCellInfos(
 	if cellInfo and not any(ci.rowNumber == row and ci.columnNumber == column for ci in fetched):
 		fetched.append(cellInfo)
 	byPosition = _indexCellInfosByPosition(fetched)
-	return _buildScopedWindow(byPosition, scope, row, column, neighbors) or None
+	window = _buildScopedWindow(byPosition, scope, row, column, neighbors)
+	return window if window else None
 
 
 def _currentCellScopeDisplay(cellInfo: EXCEL_CELLINFO, obj: NVDAObject | None) -> str:
@@ -419,7 +441,7 @@ def iterScopedBrailleSegments(
 	obj: NVDAObject,
 	window: list[EXCEL_CELLINFO] | None = None,
 ) -> Generator[ScopedBrailleSegment, None, None]:
-	if not _conf()["cellFormula"] or not _scope().isRowOrColumn:
+	if not _scope().isRowOrColumn:
 		return
 	cellInfo: EXCEL_CELLINFO | None = getattr(obj, "excelCellInfo", None)
 	if window is None:
@@ -458,7 +480,7 @@ def usesScopedBrailleRegions(
 	obj: NVDAObject | None,
 	window: list[EXCEL_CELLINFO] | None = None,
 ) -> bool:
-	if obj is None or not _conf()["cellFormula"] or not _scope().isRowOrColumn:
+	if obj is None or not _scope().isRowOrColumn:
 		return False
 	if window is not None:
 		return bool(window)
@@ -525,7 +547,11 @@ def navigateToExcelCell(focusCell: ExcelCell, row: int, column: int) -> ExcelCel
 
 
 def _cellScopeFormulaText(cellInfo: EXCEL_CELLINFO) -> str | None:
-	if not _isExcelFormula(cellInfo.formula) or not _includeFormulaForCell(isCurrent=True):
+	if (
+		not _conf()["cellFormula"]
+		or not _isExcelFormula(cellInfo.formula)
+		or not _includeFormulaForCell(isCurrent=True)
+	):
 		return None
 	formula = (cellInfo.formula or "").strip()
 	return formula or None
@@ -701,7 +727,7 @@ def uninstall_excel_braille_regions() -> None:
 
 
 def sync_excel_braille_regions_patch() -> None:
-	if _conf()["cellFormula"] and _scope().isRowOrColumn:
+	if _scope().isRowOrColumn:
 		install_excel_braille_regions()
 	else:
 		uninstall_excel_braille_regions()
@@ -829,7 +855,7 @@ def _apply_braille_buffer_focus_regions(
 
 def _build_excel_focus_regions(focus: NVDAObject) -> list:
 	window = _getScopedRangeWindow(focus, getattr(focus, "excelCellInfo", None))
-	if _conf()["cellFormula"] and _scope().isRowOrColumn and window:
+	if _scope().isRowOrColumn and window:
 		regions = _excelCellBrailleRegionsFromWindow(focus, window)
 		for region in regions:
 			region.update()
@@ -857,7 +883,7 @@ def refresh_excel_braille_display() -> None:
 	contextRegions, focusRegions = _partition_braille_buffer_regions(oldRegions)
 	scopedWindow = (
 		_getScopedRangeWindow(focus, getattr(focus, "excelCellInfo", None))
-		if _conf()["cellFormula"] and _scope().isRowOrColumn
+		if _scope().isRowOrColumn
 		else None
 	)
 	wasScopedLine = bool(focusRegions) and isinstance(focusRegions[0], ExcelCellBrailleRegion)
@@ -973,7 +999,7 @@ class AppModule(_NVDAExcelAppModule):
 
 	def event_gainFocus(self, obj, nextHandler):
 		nextHandler()
-		if not _conf()["cellFormula"] or not _scope().isRowOrColumn:
+		if not _scope().isRowOrColumn:
 			return
 		focus = _excel_focus_object_for_braille()
 		if focus is None:
@@ -986,7 +1012,7 @@ class AppModule(_NVDAExcelAppModule):
 		_focus_excel_current_at_display_left(handler, handler.mainBuffer)
 
 	@script(
-		description=_("Cycle Excel braille view (focused cell, entire row, or entire column on one line)"),
+		description=_("Cycle Excel braille view (focused cell, row range, or column range on one line)"),
 	)
 	def script_cycleExcelFormulaScope(self, gesture):
 		if not _conf()["cellFormula"]:

--- a/addon/appModules/brailleExtenderExcel.py
+++ b/addon/appModules/brailleExtenderExcel.py
@@ -110,7 +110,10 @@ def cycle_formula_scope() -> FormulaScope:
 	return new_scope
 
 
-_scopedWindowCache: dict[int, tuple[tuple[Any, ...], list[EXCEL_CELLINFO] | None]] = {}
+_scopedWindowCache: dict[
+	tuple[int, tuple[int, int] | None],
+	tuple[tuple[Any, ...], list[EXCEL_CELLINFO] | None],
+] = {}
 
 
 def _scopedSettingsKey() -> tuple[Any, ...]:
@@ -123,10 +126,26 @@ def _scopedSettingsKey() -> tuple[Any, ...]:
 
 
 def clear_scoped_braille_cache(obj: NVDAObject | None = None) -> None:
+	global _scopedWindowCache
 	if obj is None:
 		_scopedWindowCache.clear()
-	else:
-		_scopedWindowCache.pop(id(obj), None)
+		return
+	obj_id = id(obj)
+	for key in list(_scopedWindowCache):
+		if isinstance(key, tuple) and key and key[0] == obj_id:
+			del _scopedWindowCache[key]
+
+
+def _coordsToRowColumn(coords: str) -> tuple[int, int] | None:
+	local = coords.split(" through ")[0].strip().replace("$", "")
+	match = _ADDRESS_SPLIT_RE.match(local)
+	if not match:
+		return None
+	row = int(match.group(2))
+	column = _columnNumberFromLabel(match.group(1))
+	if row < 1 or column < 1:
+		return None
+	return row, column
 
 
 def _getScopedRangeWindow(
@@ -139,7 +158,9 @@ def _getScopedRangeWindow(
 	if not scope.isRowOrColumn:
 		return None
 	settings_key = _scopedSettingsKey()
-	cache_key = id(obj)
+	position = _focusRowColumn(obj, cellInfo)
+	position_key = position[:2] if position else None
+	cache_key = (id(obj), position_key)
 	cached = _scopedWindowCache.get(cache_key)
 	if cached is not None and cached[0] == settings_key:
 		return cached[1]
@@ -301,6 +322,60 @@ def _currentCoords(obj: NVDAObject, cellInfo: EXCEL_CELLINFO | None) -> str | No
 	return None
 
 
+def _focusRowColumn(
+	obj: NVDAObject,
+	cellInfo: EXCEL_CELLINFO | None,
+) -> tuple[int, int, str] | None:
+	"""Row, column, and A1-style label for the focused cell in scoped braille."""
+	row: int | None = None
+	column: int | None = None
+	context = _getExcelCellContext(obj)
+	if context is not None:
+		row, column = int(context[1]), int(context[2])
+	if (row is None or column is None or row < 1 or column < 1) and cellInfo:
+		if cellInfo.rowNumber >= 1 and cellInfo.columnNumber >= 1:
+			row, column = cellInfo.rowNumber, cellInfo.columnNumber
+	if row is None or column is None or row < 1 or column < 1:
+		try:
+			obj_row = obj.rowNumber
+			obj_column = obj.columnNumber
+		except (AttributeError, NotImplementedError, TypeError):
+			obj_row = obj_column = None
+		if obj_row and obj_column:
+			row, column = int(obj_row), int(obj_column)
+	if row is None or column is None or row < 1 or column < 1:
+		coords = _currentCoords(obj, cellInfo)
+		if coords:
+			parsed = _coordsToRowColumn(coords)
+			if parsed:
+				row, column = parsed
+	if row is None or column is None or row < 1 or column < 1:
+		return None
+	coordsLabel = f"{_columnLabel(column)}{row}"
+	labeled = _currentCoords(obj, cellInfo)
+	if labeled:
+		local = labeled.split(" through ")[0].strip().replace("$", "")
+		parsed = _coordsToRowColumn(local)
+		if parsed == (row, column):
+			coordsLabel = local
+	return row, column, coordsLabel
+
+
+def _cellInfoIsCurrentFocus(
+	cellInfo: EXCEL_CELLINFO,
+	currentRow: int,
+	currentColumn: int,
+) -> bool:
+	if cellInfo.rowNumber == currentRow and cellInfo.columnNumber == currentColumn:
+		return True
+	if cellInfo.rowNumber < 1 or cellInfo.columnNumber < 1:
+		local = _localAddress(cellInfo)
+		if local:
+			parsed = _coordsToRowColumn(local)
+			return parsed == (currentRow, currentColumn)
+	return False
+
+
 def _cellContent(cellInfo: EXCEL_CELLINFO, *, isCurrent: bool) -> str:
 	if not isCurrent and not _isPrimaryMergeCell(cellInfo):
 		return ""
@@ -347,7 +422,7 @@ def _buildScopedWindow(
 		(
 			i
 			for i, cellInfo in enumerate(window)
-			if cellInfo.rowNumber == currentRow and cellInfo.columnNumber == currentColumn
+			if _cellInfoIsCurrentFocus(cellInfo, currentRow, currentColumn)
 		),
 		None,
 	)
@@ -367,10 +442,14 @@ def _getExcelCellContext(obj: NVDAObject) -> tuple[Any, int, int, Any, int] | No
 		return None
 	try:
 		excelCell = obj.excelCellObject
+		row = int(excelCell.row)
+		column = int(excelCell.column)
+		if row < 1 or column < 1:
+			return None
 		return (
 			excelCell,
-			int(excelCell.row),
-			int(excelCell.column),
+			row,
+			column,
 			excelCell.Worksheet,
 			int(_conf()["cellFormulaNeighbors"]),
 		)
@@ -404,7 +483,12 @@ def _fetchScopedRangeCellInfos(
 		return None
 
 	fetched = _fetchCellInfos(obj, rangeAddress, cellCount)
-	if cellInfo and not any(ci.rowNumber == row and ci.columnNumber == column for ci in fetched):
+	if (
+		cellInfo
+		and cellInfo.rowNumber == row
+		and cellInfo.columnNumber == column
+		and not any(ci.rowNumber == row and ci.columnNumber == column for ci in fetched)
+	):
 		fetched.append(cellInfo)
 	byPosition = _indexCellInfosByPosition(fetched)
 	window = _buildScopedWindow(byPosition, scope, row, column, neighbors)
@@ -437,6 +521,72 @@ def _segmentEntry(
 	return content if content else ""
 
 
+def _minimalScopedSegment(
+	obj: NVDAObject,
+	window: list[EXCEL_CELLINFO],
+	currentRow: int,
+	currentColumn: int,
+	currentCoords: str,
+) -> ScopedBrailleSegment:
+	scope = _scope()
+	linePrefix = (
+		f"{scope.prefixLetter}{currentRow} "
+		if scope == FormulaScope.ROW
+		else f"{scope.prefixLetter}{_columnLabel(currentColumn)} "
+	)
+	cellInfo = next(
+		(info for info in window if _cellInfoIsCurrentFocus(info, currentRow, currentColumn)),
+		None,
+	)
+	if cellInfo is None:
+		cellInfo = _emptyCellInfo(currentRow, currentColumn)
+	entry = _segmentEntry(
+		cellInfo,
+		isCurrent=True,
+		currentCoords=currentCoords,
+		obj=obj,
+	)
+	return ScopedBrailleSegment(linePrefix + entry, currentRow, currentColumn, True)
+
+
+def _ensureCurrentSegmentInList(
+	obj: NVDAObject,
+	segments: list[ScopedBrailleSegment],
+	window: list[EXCEL_CELLINFO],
+) -> list[ScopedBrailleSegment]:
+	if any(segment.isCurrent for segment in segments):
+		return segments
+	position = _focusRowColumn(obj, getattr(obj, "excelCellInfo", None))
+	if position is None:
+		return segments
+	currentRow, currentColumn, currentCoords = position
+	for index, segment in enumerate(segments):
+		if segment.row == currentRow and segment.column == currentColumn:
+			fixed = _minimalScopedSegment(obj, window, currentRow, currentColumn, currentCoords)
+			updated = list(segments)
+			if index == 0:
+				updated[0] = fixed
+			else:
+				separator = str(_conf()["cellFormulaSeparator"] or " | ")
+				entry = _segmentEntry(
+					next(
+						(info for info in window if _cellInfoIsCurrentFocus(info, currentRow, currentColumn)),
+						_emptyCellInfo(currentRow, currentColumn),
+					),
+					isCurrent=True,
+					currentCoords=currentCoords,
+					obj=obj,
+				)
+				updated[index] = ScopedBrailleSegment(
+					separator + entry,
+					currentRow,
+					currentColumn,
+					True,
+				)
+			return updated
+	return [_minimalScopedSegment(obj, window, currentRow, currentColumn, currentCoords), *segments]
+
+
 def iterScopedBrailleSegments(
 	obj: NVDAObject,
 	window: list[EXCEL_CELLINFO] | None = None,
@@ -448,13 +598,10 @@ def iterScopedBrailleSegments(
 		window = _getScopedRangeWindow(obj, cellInfo)
 	if not window:
 		return
-	currentCoords = _currentCoords(obj, cellInfo)
-	if not currentCoords:
+	position = _focusRowColumn(obj, cellInfo)
+	if position is None:
 		return
-	context = _getExcelCellContext(obj)
-	if context is None:
-		return
-	_, currentRow, currentColumn, _, _ = context
+	currentRow, currentColumn, currentCoords = position
 
 	separator = str(_conf()["cellFormulaSeparator"] or " | ")
 	scope = _scope()
@@ -465,7 +612,7 @@ def iterScopedBrailleSegments(
 	)
 
 	for index, info in enumerate(window):
-		isCurrent = info.rowNumber == currentRow and info.columnNumber == currentColumn
+		isCurrent = _cellInfoIsCurrentFocus(info, currentRow, currentColumn)
 		entry = _segmentEntry(
 			info,
 			isCurrent=isCurrent,
@@ -666,6 +813,15 @@ def _excelCellBrailleRegionsFromWindow(
 	cellInfo: EXCEL_CELLINFO | None = getattr(focusCell, "excelCellInfo", None)
 	currentCoords = _currentCoords(focusCell, cellInfo)
 	segments = list(iterScopedBrailleSegments(focusCell, window))
+	if not segments:
+		position = _focusRowColumn(focusCell, cellInfo)
+		if position is not None:
+			currentRow, currentColumn, coords = position
+			if not currentCoords:
+				currentCoords = coords
+			segments = [_minimalScopedSegment(focusCell, window, currentRow, currentColumn, coords)]
+	else:
+		segments = _ensureCurrentSegmentInList(focusCell, segments, window)
 	regions: list[ExcelCellBrailleRegion] = []
 	for segment in segments:
 		regions.append(
@@ -691,7 +847,13 @@ def excelCell_getBrailleRegions(
 		if _originalExcelCellGetBrailleRegions is not None:
 			return _originalExcelCellGetBrailleRegions(obj, review=review)
 		raise NotImplementedError
-	for region in _excelCellBrailleRegionsFromWindow(obj, window):
+	regions = _excelCellBrailleRegionsFromWindow(obj, window)
+	if not regions:
+		# NVDA treats an empty custom generator as success; fall back to default regions.
+		if _originalExcelCellGetBrailleRegions is not None:
+			return _originalExcelCellGetBrailleRegions(obj, review=review)
+		raise NotImplementedError
+	for region in regions:
 		yield region
 
 
@@ -787,7 +949,7 @@ def _excel_primary_focus_region(focusRegions: list) -> Any | None:
 	for region in focusRegions:
 		if getattr(region, "isCurrentSegment", False):
 			return region
-	return focusRegions[-1] if focusRegions else None
+	return focusRegions[0] if focusRegions else None
 
 
 def _focus_excel_current_at_display_left(
@@ -857,9 +1019,10 @@ def _build_excel_focus_regions(focus: NVDAObject) -> list:
 	window = _getScopedRangeWindow(focus, getattr(focus, "excelCellInfo", None))
 	if _scope().isRowOrColumn and window:
 		regions = _excelCellBrailleRegionsFromWindow(focus, window)
-		for region in regions:
-			region.update()
-		return regions
+		if regions:
+			for region in regions:
+				region.update()
+			return regions
 	region = braille.NVDAObjectRegion(focus)
 	region.focusToHardLeft = True
 	region.update()
@@ -932,15 +1095,28 @@ def refresh_excel_braille_display() -> None:
 _headerTextGuardsInstalled = False
 _originalGetRowHeaderText: Any = None
 _originalGetColumnHeaderText: Any = None
+_originalFetchAssociatedHeaderCellText: Any = None
 
 
-def _excelCellCoordinatesReady(cell: ExcelCell) -> bool:
-	info = cell.excelCellInfo
-	if info is None:
+def _excelCellCoordinatesReady(cell: NVDAObject) -> bool:
+	try:
+		rowNumber = cell.rowNumber
+		columnNumber = cell.columnNumber
+	except (AttributeError, NotImplementedError, TypeError):
 		return False
-	rowNumber = info.rowNumber
-	columnNumber = info.columnNumber
-	return isinstance(rowNumber, int) and isinstance(columnNumber, int)
+	return (
+		isinstance(rowNumber, int) and isinstance(columnNumber, int) and rowNumber >= 1 and columnNumber >= 1
+	)
+
+
+def _safeFetchAssociatedHeaderCellText(self, cell, columnHeader: bool = False) -> str | None:
+	if not _excelCellCoordinatesReady(cell):
+		return None
+	try:
+		return _originalFetchAssociatedHeaderCellText(self, cell, columnHeader=columnHeader)
+	except (TypeError, ValueError, COMError, AttributeError, NotImplementedError):
+		log.debugWarning("Excel header text lookup failed", exc_info=True)
+		return None
 
 
 def _safeGetRowHeaderText(self: ExcelCell) -> str | None:
@@ -948,7 +1124,7 @@ def _safeGetRowHeaderText(self: ExcelCell) -> str | None:
 		return None
 	try:
 		return _originalGetRowHeaderText(self)
-	except (TypeError, ValueError, COMError):
+	except (TypeError, ValueError, COMError, AttributeError, NotImplementedError):
 		log.debugWarning("Excel row header text lookup failed", exc_info=True)
 		return None
 
@@ -958,18 +1134,20 @@ def _safeGetColumnHeaderText(self: ExcelCell) -> str | None:
 		return None
 	try:
 		return _originalGetColumnHeaderText(self)
-	except (TypeError, ValueError, COMError):
+	except (TypeError, ValueError, COMError, AttributeError, NotImplementedError):
 		log.debugWarning("Excel column header text lookup failed", exc_info=True)
 		return None
 
 
 def install_excel_header_text_guards() -> None:
 	global _headerTextGuardsInstalled, _originalGetRowHeaderText, _originalGetColumnHeaderText
-	from NVDAObjects.window.excel import ExcelCell, ExcelMergedCell
-
-	if ExcelCell._get_rowHeaderText is _safeGetRowHeaderText:
-		_headerTextGuardsInstalled = True
+	global _originalFetchAssociatedHeaderCellText
+	if _headerTextGuardsInstalled:
 		return
+	from NVDAObjects.window.excel import ExcelCell, ExcelMergedCell, ExcelWorksheet
+
+	_originalFetchAssociatedHeaderCellText = ExcelWorksheet.fetchAssociatedHeaderCellText
+	ExcelWorksheet.fetchAssociatedHeaderCellText = _safeFetchAssociatedHeaderCellText
 	_originalGetRowHeaderText = ExcelCell._get_rowHeaderText
 	_originalGetColumnHeaderText = ExcelCell._get_columnHeaderText
 	for cls in (ExcelCell, ExcelMergedCell):
@@ -980,15 +1158,19 @@ def install_excel_header_text_guards() -> None:
 
 def uninstall_excel_header_text_guards() -> None:
 	global _headerTextGuardsInstalled, _originalGetRowHeaderText, _originalGetColumnHeaderText
+	global _originalFetchAssociatedHeaderCellText
 	if not _headerTextGuardsInstalled:
 		return
-	from NVDAObjects.window.excel import ExcelCell, ExcelMergedCell
+	from NVDAObjects.window.excel import ExcelCell, ExcelMergedCell, ExcelWorksheet
 
+	if _originalFetchAssociatedHeaderCellText is not None:
+		ExcelWorksheet.fetchAssociatedHeaderCellText = _originalFetchAssociatedHeaderCellText
 	for cls in (ExcelCell, ExcelMergedCell):
 		if _originalGetRowHeaderText is not None:
 			cls._get_rowHeaderText = _originalGetRowHeaderText
 		if _originalGetColumnHeaderText is not None:
 			cls._get_columnHeaderText = _originalGetColumnHeaderText
+	_originalFetchAssociatedHeaderCellText = None
 	_originalGetRowHeaderText = None
 	_originalGetColumnHeaderText = None
 	_headerTextGuardsInstalled = False
@@ -999,6 +1181,8 @@ class AppModule(_NVDAExcelAppModule):
 
 	def event_gainFocus(self, obj, nextHandler):
 		nextHandler()
+		if isExcelWorksheetCell(obj):
+			clear_scoped_braille_cache(obj)
 		if not _scope().isRowOrColumn:
 			return
 		focus = _excel_focus_object_for_braille()

--- a/addon/appModules/brailleExtenderExcel.py
+++ b/addon/appModules/brailleExtenderExcel.py
@@ -16,6 +16,7 @@ import addonHandler
 import api
 import braille
 import config
+import core
 import eventHandler
 import keyboardHandler
 from comtypes import COMError
@@ -105,7 +106,7 @@ def cycle_formula_scope() -> FormulaScope:
 	scopes = list(FormulaScope)
 	current = _scope()
 	new_scope = scopes[(scopes.index(current) + 1) % len(scopes)]
-	_conf()["cellFormulaScope"] = new_scope
+	_conf()["cellFormulaScope"] = new_scope.value
 	return new_scope
 
 
@@ -716,6 +717,35 @@ def _excel_focus_object_for_braille() -> NVDAObject | None:
 	return None
 
 
+def _excel_cell_from_braille_buffer(handler: braille.BrailleHandler) -> NVDAObject | None:
+	for region in reversed(handler.mainBuffer.regions):
+		if isinstance(region, ExcelCellBrailleRegion):
+			cell = region._focusCell or region.obj
+			if cell is not None:
+				return cell
+		regionObj = getattr(region, "obj", None)
+		if regionObj is not None and (
+			hasattr(regionObj, "excelCellInfo") or hasattr(regionObj, "excelCellObject")
+		):
+			return regionObj
+	return None
+
+
+def _resolve_excel_cell_for_braille_refresh() -> NVDAObject | None:
+	cell = _excel_focus_object_for_braille()
+	if cell is not None:
+		return cell
+	handler = braille.handler
+	if handler is None or not handler.enabled:
+		return None
+	return _excel_cell_from_braille_buffer(handler)
+
+
+def schedule_excel_braille_refresh() -> None:
+	# Defer until the settings dialog closes; focus is not on a cell during onSave.
+	core.callLater(0, refresh_excel_braille_display)
+
+
 def _partition_braille_buffer_regions(regions: list) -> tuple[list, list]:
 	contextRegions: list = []
 	focusRegions: list = []
@@ -814,11 +844,11 @@ def refresh_excel_braille_display() -> None:
 	handler = braille.handler
 	if handler is None or not handler.enabled:
 		return
-	focus = _excel_focus_object_for_braille()
+	sync_excel_braille_regions_patch()
+	clear_scoped_braille_cache()
+	focus = _resolve_excel_cell_for_braille_refresh()
 	if focus is None:
 		return
-	sync_excel_braille_regions_patch()
-	clear_scoped_braille_cache(focus)
 	focus.invalidateCache()
 	if handler.buffer is not handler.mainBuffer:
 		handler.buffer = handler.mainBuffer
@@ -970,6 +1000,5 @@ class AppModule(_NVDAExcelAppModule):
 			)
 			return
 		new_scope = cycle_formula_scope()
-		clear_scoped_braille_cache()
 		refresh_excel_braille_display()
 		speakMessage(new_scope.label)

--- a/addon/appModules/brailleExtenderExcel.py
+++ b/addon/appModules/brailleExtenderExcel.py
@@ -56,16 +56,19 @@ class FormulaScope(StrEnum):
 	def isRowOrColumn(self) -> bool:
 		return self in (FormulaScope.ROW, FormulaScope.COLUMN)
 
-	@property
-	def prefixLetter(self) -> str:
-		return "r" if self == FormulaScope.ROW else "c"
-
 
 SCOPE_LABELS: dict[FormulaScope, str] = {
 	FormulaScope.CELL: _("Focused cell only"),
 	FormulaScope.ROW: _("Row range on one line"),
 	FormulaScope.COLUMN: _("Column range on one line"),
 }
+
+# Translators: Default short label at the start of an Excel row-range braille line, before the cell address.
+# English example on the display: "row A2: sale |  | 99". Keep brief. Do not add spaces at the end.
+_AXIS_PREFIX_ROW_DEFAULT = pgettext("excelBrailleAxis", "row")
+# Translators: Default short label at the start of an Excel column-range braille line, before the cell address.
+# English example on the display: "col A2: sale |  | 99". Keep brief. Do not add spaces at the end.
+_AXIS_PREFIX_COLUMN_DEFAULT = pgettext("excelBrailleAxis", "col")
 
 
 class ScopeFormulaDisplay(StrEnum):
@@ -116,12 +119,30 @@ _scopedWindowCache: dict[
 ] = {}
 
 
+def _configuredAxisPrefix(configKey: str, default: str) -> str:
+	custom = str(_conf()[configKey] or "").strip()
+	return custom if custom else default
+
+
+def _scopedLinePrefix(scope: FormulaScope | None = None) -> str:
+	scope = scope or _scope()
+	if scope == FormulaScope.ROW:
+		text = _configuredAxisPrefix("rowAxisPrefix", _AXIS_PREFIX_ROW_DEFAULT)
+	elif scope == FormulaScope.COLUMN:
+		text = _configuredAxisPrefix("columnAxisPrefix", _AXIS_PREFIX_COLUMN_DEFAULT)
+	else:
+		return ""
+	return f"{text} "
+
+
 def _scopedSettingsKey() -> tuple[Any, ...]:
 	return (
 		_scope(),
 		int(_conf()["cellFormulaNeighbors"]),
 		_scopeFormulaDisplay(),
 		str(_conf()["cellFormulaSeparator"] or " | "),
+		_configuredAxisPrefix("rowAxisPrefix", _AXIS_PREFIX_ROW_DEFAULT),
+		_configuredAxisPrefix("columnAxisPrefix", _AXIS_PREFIX_COLUMN_DEFAULT),
 	)
 
 
@@ -528,12 +549,7 @@ def _minimalScopedSegment(
 	currentColumn: int,
 	currentCoords: str,
 ) -> ScopedBrailleSegment:
-	scope = _scope()
-	linePrefix = (
-		f"{scope.prefixLetter}{currentRow} "
-		if scope == FormulaScope.ROW
-		else f"{scope.prefixLetter}{_columnLabel(currentColumn)} "
-	)
+	linePrefix = _scopedLinePrefix()
 	cellInfo = next(
 		(info for info in window if _cellInfoIsCurrentFocus(info, currentRow, currentColumn)),
 		None,
@@ -604,12 +620,7 @@ def iterScopedBrailleSegments(
 	currentRow, currentColumn, currentCoords = position
 
 	separator = str(_conf()["cellFormulaSeparator"] or " | ")
-	scope = _scope()
-	linePrefix = (
-		f"{scope.prefixLetter}{currentRow} "
-		if scope == FormulaScope.ROW
-		else f"{scope.prefixLetter}{_columnLabel(currentColumn)} "
-	)
+	linePrefix = _scopedLinePrefix()
 
 	for index, info in enumerate(window):
 		isCurrent = _cellInfoIsCurrentFocus(info, currentRow, currentColumn)

--- a/addon/appModules/brailleExtenderExcel.py
+++ b/addon/appModules/brailleExtenderExcel.py
@@ -1,0 +1,975 @@
+# coding: utf-8
+# brailleExtenderExcel.py
+# Part of Braille Extender addon for NVDA
+# Copyright 2026 André-Abush Clause, released under GPL.
+
+from __future__ import annotations
+
+import ctypes
+import itertools
+import re
+from collections.abc import Generator, Iterable
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+import addonHandler
+import api
+import braille
+import config
+import eventHandler
+import keyboardHandler
+from comtypes import COMError
+from comtypes.automation import BSTR
+from logHandler import log
+from scriptHandler import script
+from speech import speakMessage
+import NVDAHelper
+from NVDAHelper.localLib import EXCEL_CELLINFO
+from NVDAObjects.window.excel import convertAddressToLocal
+
+from appModules.excel import AppModule as _NVDAExcelAppModule
+
+from globalPlugins.brailleExtender.common import addonName
+
+if TYPE_CHECKING:
+	from NVDAObjects import NVDAObject
+	from NVDAObjects.window.excel import ExcelCell
+
+addonHandler.initTranslation()
+
+_CELL_INFO_FLAGS = 0x1 | 0x2 | 0x10 | 0x80
+_XL_A1 = 1
+_ADDRESS_SPLIT_RE = re.compile(r"^([A-Za-z]+)(\d+)")
+
+
+class FormulaScope(StrEnum):
+	CELL = auto()
+	ROW = auto()
+	COLUMN = auto()
+
+	@property
+	def label(self) -> str:
+		return SCOPE_LABELS[self]
+
+	@property
+	def isRowOrColumn(self) -> bool:
+		return self in (FormulaScope.ROW, FormulaScope.COLUMN)
+
+	@property
+	def prefixLetter(self) -> str:
+		return "r" if self == FormulaScope.ROW else "c"
+
+
+SCOPE_LABELS: dict[FormulaScope, str] = {
+	FormulaScope.CELL: _("Current cell only"),
+	FormulaScope.ROW: _("Current row"),
+	FormulaScope.COLUMN: _("Current column"),
+}
+
+
+class ScopeFormulaDisplay(StrEnum):
+	ACTIVE_CELL = auto()
+	ALL = auto()
+	NONE = auto()
+
+
+class ExcelBrailleResult(NamedTuple):
+	description: str | None
+	suppress_name: bool
+	suppress_coords: bool
+
+	@staticmethod
+	def empty() -> ExcelBrailleResult:
+		return ExcelBrailleResult(None, False, False)
+
+
+class ScopedBrailleSegment(NamedTuple):
+	text: str
+	row: int
+	column: int
+	isCurrent: bool
+
+
+def _conf() -> Any:
+	return config.conf["brailleExtender"]["excel"]
+
+
+def _scope() -> FormulaScope:
+	try:
+		return FormulaScope(_conf()["cellFormulaScope"])
+	except ValueError:
+		return FormulaScope.CELL
+
+
+def cycle_formula_scope() -> FormulaScope:
+	scopes = list(FormulaScope)
+	current = _scope()
+	new_scope = scopes[(scopes.index(current) + 1) % len(scopes)]
+	_conf()["cellFormulaScope"] = new_scope
+	return new_scope
+
+
+_scopedWindowCache: dict[int, tuple[tuple[Any, ...], list[EXCEL_CELLINFO] | None]] = {}
+
+
+def _scopedSettingsKey() -> tuple[Any, ...]:
+	return (
+		_scope(),
+		int(_conf()["cellFormulaNeighbors"]),
+		_scopeFormulaDisplay(),
+		str(_conf()["cellFormulaSeparator"] or " | "),
+	)
+
+
+def clear_scoped_braille_cache(obj: NVDAObject | None = None) -> None:
+	if obj is None:
+		_scopedWindowCache.clear()
+	else:
+		_scopedWindowCache.pop(id(obj), None)
+
+
+def _getScopedRangeWindow(
+	obj: NVDAObject,
+	cellInfo: EXCEL_CELLINFO | None = None,
+	*,
+	scope: FormulaScope | None = None,
+) -> list[EXCEL_CELLINFO] | None:
+	scope = scope or _scope()
+	if not _conf()["cellFormula"] or not scope.isRowOrColumn:
+		return None
+	settings_key = _scopedSettingsKey()
+	cache_key = id(obj)
+	cached = _scopedWindowCache.get(cache_key)
+	if cached is not None and cached[0] == settings_key:
+		return cached[1]
+	window = _fetchScopedRangeCellInfos(obj, cellInfo, scope)
+	_scopedWindowCache[cache_key] = (settings_key, window)
+	return window
+
+
+def _scopeFormulaDisplay() -> ScopeFormulaDisplay:
+	try:
+		return ScopeFormulaDisplay(_conf()["scopeFormulaDisplay"])
+	except ValueError:
+		return ScopeFormulaDisplay.ACTIVE_CELL
+
+
+def isExcelWorksheetCell(obj: NVDAObject | None) -> bool:
+	if obj is None:
+		return False
+	if not hasattr(obj, "excelCellObject"):
+		return False
+	return bool(getattr(obj.appModule, "helperLocalBindingHandle", None))
+
+
+def _includeFormulaForCell(isCurrent: bool) -> bool:
+	display = _scopeFormulaDisplay()
+	if display == ScopeFormulaDisplay.ALL:
+		return True
+	if display == ScopeFormulaDisplay.NONE:
+		return False
+	return isCurrent
+
+
+def _isExcelFormula(formula: str | None) -> bool:
+	return (formula or "").strip().startswith("=")
+
+
+def _localAddress(cellInfo: EXCEL_CELLINFO) -> str | None:
+	if not cellInfo.address:
+		return None
+	return cellInfo.address.split("!")[-1].split(":")[0]
+
+
+def _columnLabel(columnNumber: int) -> str:
+	label = ""
+	column = columnNumber
+	while column > 0:
+		column, remainder = divmod(column - 1, 26)
+		label = chr(65 + remainder) + label
+	return label
+
+
+def _columnNumberFromLabel(label: str) -> int:
+	number = 0
+	for character in label.upper():
+		number = number * 26 + (ord(character) - 64)
+	return number
+
+
+def _mergeAnchor(address: str | None) -> tuple[int, int] | None:
+	if not address:
+		return None
+	local = address.split("!")[-1]
+	if ":" not in local:
+		return None
+	start = local.split(":", 1)[0].strip("$")
+	match = _ADDRESS_SPLIT_RE.match(start)
+	if not match:
+		return None
+	return int(match.group(2)), _columnNumberFromLabel(match.group(1))
+
+
+def _isPrimaryMergeCell(cellInfo: EXCEL_CELLINFO) -> bool:
+	anchor = _mergeAnchor(cellInfo.address)
+	if anchor is None:
+		return True
+	return (cellInfo.rowNumber, cellInfo.columnNumber) == anchor
+
+
+def _cellInfoRichness(cellInfo: EXCEL_CELLINFO) -> int:
+	return int(_isExcelFormula(cellInfo.formula)) + int(bool((cellInfo.text or "").strip()))
+
+
+def _indexCellInfosByPosition(cellInfos: Iterable[EXCEL_CELLINFO]) -> dict[tuple[int, int], EXCEL_CELLINFO]:
+	byPosition: dict[tuple[int, int], EXCEL_CELLINFO] = {}
+	for cellInfo in cellInfos:
+		row, column = cellInfo.rowNumber, cellInfo.columnNumber
+		if row < 1 or column < 1:
+			continue
+		key = (row, column)
+		existing = byPosition.get(key)
+		if existing is None or _cellInfoRichness(cellInfo) > _cellInfoRichness(existing):
+			byPosition[key] = cellInfo
+	return byPosition
+
+
+def _fetchCellInfos(obj: NVDAObject, rangeAddress: str, cellCount: int) -> list[EXCEL_CELLINFO]:
+	handle = getattr(obj.appModule, "helperLocalBindingHandle", None)
+	if not handle or cellCount <= 0:
+		return []
+	cellInfos = (EXCEL_CELLINFO * cellCount)()
+	numFetched = ctypes.c_long()
+	try:
+		localAddress = convertAddressToLocal(obj.excelCellObject.Application, rangeAddress)
+	except (AttributeError, COMError):
+		return []
+	if (
+		NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(
+			handle,
+			obj.windowHandle,
+			BSTR(localAddress),
+			_CELL_INFO_FLAGS,
+			cellCount,
+			cellInfos,
+			ctypes.byref(numFetched),
+		)
+		!= 0
+		or numFetched.value <= 0
+	):
+		return []
+	return [
+		cellInfos[i]
+		for i in range(numFetched.value)
+		if cellInfos[i].address or (cellInfos[i].rowNumber and cellInfos[i].columnNumber)
+	]
+
+
+def _emptyCellInfo(rowNumber: int, columnNumber: int) -> EXCEL_CELLINFO:
+	cellInfo = EXCEL_CELLINFO()
+	cellInfo.rowNumber = rowNumber
+	cellInfo.columnNumber = columnNumber
+	return cellInfo
+
+
+def _currentCoords(obj: NVDAObject, cellInfo: EXCEL_CELLINFO | None) -> str | None:
+	try:
+		if obj.cellCoordsText:
+			return obj.cellCoordsText
+	except (AttributeError, NotImplementedError):
+		pass
+	return _localAddress(cellInfo) if cellInfo else None
+
+
+def _cellContent(cellInfo: EXCEL_CELLINFO, *, isCurrent: bool) -> str:
+	if not isCurrent and not _isPrimaryMergeCell(cellInfo):
+		return ""
+	formula = (cellInfo.formula or "").strip()
+	text = (cellInfo.text or "").strip()
+	if _isExcelFormula(formula) and _includeFormulaForCell(isCurrent):
+		return f"{text} {formula}" if text else formula
+	return text
+
+
+def _hasDisplayContent(cellInfo: EXCEL_CELLINFO, *, isCurrent: bool) -> bool:
+	if not isCurrent and not _isPrimaryMergeCell(cellInfo):
+		return False
+	if (cellInfo.text or "").strip():
+		return True
+	return _isExcelFormula(cellInfo.formula) and _includeFormulaForCell(isCurrent)
+
+
+def _buildScopedWindow(
+	byPosition: dict[tuple[int, int], EXCEL_CELLINFO],
+	scope: FormulaScope,
+	currentRow: int,
+	currentColumn: int,
+	neighbors: int,
+) -> list[EXCEL_CELLINFO]:
+	if scope == FormulaScope.ROW:
+		start = max(1, currentColumn - neighbors)
+		end = currentColumn + neighbors
+		window = [
+			byPosition.get((currentRow, column)) or _emptyCellInfo(currentRow, column)
+			for column in range(start, end + 1)
+		]
+	else:
+		start = max(1, currentRow - neighbors)
+		end = currentRow + neighbors
+		window = [
+			byPosition.get((row, currentColumn)) or _emptyCellInfo(row, currentColumn)
+			for row in range(start, end + 1)
+		]
+
+	currentIndex = next(
+		(
+			i
+			for i, cellInfo in enumerate(window)
+			if cellInfo.rowNumber == currentRow and cellInfo.columnNumber == currentColumn
+		),
+		None,
+	)
+	if currentIndex is None:
+		return window
+
+	contentIndices = [
+		i for i, cellInfo in enumerate(window) if _hasDisplayContent(cellInfo, isCurrent=(i == currentIndex))
+	]
+	if currentIndex not in contentIndices:
+		contentIndices.append(currentIndex)
+	return window[min(contentIndices) : max(contentIndices) + 1]
+
+
+def _getExcelCellContext(obj: NVDAObject) -> tuple[Any, int, int, Any, int] | None:
+	if not isExcelWorksheetCell(obj):
+		return None
+	try:
+		excelCell = obj.excelCellObject
+		return (
+			excelCell,
+			int(excelCell.row),
+			int(excelCell.column),
+			excelCell.Worksheet,
+			int(_conf()["cellFormulaNeighbors"]),
+		)
+	except (AttributeError, COMError, TypeError, ValueError):
+		return None
+
+
+def _fetchScopedRangeCellInfos(
+	obj: NVDAObject,
+	cellInfo: EXCEL_CELLINFO | None,
+	scope: FormulaScope,
+) -> list[EXCEL_CELLINFO] | None:
+	context = _getExcelCellContext(obj)
+	if context is None:
+		return None
+	excelCell, row, column, worksheet, neighbors = context
+	try:
+		if scope == FormulaScope.ROW:
+			cellRange = worksheet.Range(
+				worksheet.Cells(row, max(1, column - neighbors)),
+				worksheet.Cells(row, column + neighbors),
+			)
+		else:
+			cellRange = worksheet.Range(
+				worksheet.Cells(max(1, row - neighbors), column),
+				worksheet.Cells(row + neighbors, column),
+			)
+		rangeAddress = cellRange.address(True, True, _XL_A1, True)
+		cellCount = cellRange.Count
+	except (AttributeError, COMError):
+		return None
+
+	fetched = _fetchCellInfos(obj, rangeAddress, cellCount)
+	if cellInfo and not any(ci.rowNumber == row and ci.columnNumber == column for ci in fetched):
+		fetched.append(cellInfo)
+	byPosition = _indexCellInfosByPosition(fetched)
+	return _buildScopedWindow(byPosition, scope, row, column, neighbors) or None
+
+
+def _currentCellScopeDisplay(cellInfo: EXCEL_CELLINFO, obj: NVDAObject | None) -> str:
+	display = _cellContent(cellInfo, isCurrent=True)
+	if display:
+		return display
+	try:
+		if obj is not None and obj.name:
+			return obj.name.strip()
+	except AttributeError:
+		pass
+	return (cellInfo.text or "").strip()
+
+
+def _segmentEntry(
+	cellInfo: EXCEL_CELLINFO,
+	*,
+	isCurrent: bool,
+	currentCoords: str,
+	obj: NVDAObject,
+) -> str:
+	if isCurrent:
+		display = _currentCellScopeDisplay(cellInfo, obj)
+		return f"{currentCoords}: {display}" if display else f"{currentCoords}:"
+	content = _cellContent(cellInfo, isCurrent=False)
+	return content if content else ""
+
+
+def iterScopedBrailleSegments(
+	obj: NVDAObject,
+	window: list[EXCEL_CELLINFO] | None = None,
+) -> Generator[ScopedBrailleSegment, None, None]:
+	if not _conf()["cellFormula"] or not _scope().isRowOrColumn:
+		return
+	cellInfo: EXCEL_CELLINFO | None = getattr(obj, "excelCellInfo", None)
+	if window is None:
+		window = _getScopedRangeWindow(obj, cellInfo)
+	if not window:
+		return
+	currentCoords = _currentCoords(obj, cellInfo)
+	if not currentCoords:
+		return
+	context = _getExcelCellContext(obj)
+	if context is None:
+		return
+	_, currentRow, currentColumn, _, _ = context
+
+	separator = str(_conf()["cellFormulaSeparator"] or " | ")
+	scope = _scope()
+	linePrefix = (
+		f"{scope.prefixLetter}{currentRow} "
+		if scope == FormulaScope.ROW
+		else f"{scope.prefixLetter}{_columnLabel(currentColumn)} "
+	)
+
+	for index, info in enumerate(window):
+		isCurrent = info.rowNumber == currentRow and info.columnNumber == currentColumn
+		entry = _segmentEntry(
+			info,
+			isCurrent=isCurrent,
+			currentCoords=currentCoords,
+			obj=obj,
+		)
+		text = linePrefix + entry if index == 0 else separator + entry
+		yield ScopedBrailleSegment(text, info.rowNumber, info.columnNumber, isCurrent)
+
+
+def usesScopedBrailleRegions(
+	obj: NVDAObject | None,
+	window: list[EXCEL_CELLINFO] | None = None,
+) -> bool:
+	if obj is None or not _conf()["cellFormula"] or not _scope().isRowOrColumn:
+		return False
+	if window is not None:
+		return bool(window)
+	return _getScopedRangeWindow(obj, getattr(obj, "excelCellInfo", None)) is not None
+
+
+def _excelHeaderSuffix(obj: NVDAObject) -> str:
+	suffix = ""
+	try:
+		columnHeader = getattr(obj, "columnHeaderText", None)
+		if columnHeader:
+			suffix += "⣀" + columnHeader
+	except (NotImplementedError, TypeError):
+		pass
+	try:
+		rowHeader = getattr(obj, "rowHeaderText", None)
+		if rowHeader:
+			suffix += "⡀" + rowHeader
+	except (NotImplementedError, TypeError):
+		pass
+	return suffix
+
+
+def excelCellAt(focusCell: ExcelCell, row: int, column: int) -> ExcelCell | None:
+	from NVDAObjects.window.excel import ExcelCell, ExcelMergedCell
+
+	context = _getExcelCellContext(focusCell)
+	if context is None:
+		return None
+	_, _, _, worksheet, _ = context
+	try:
+		cellPosition = worksheet.Cells(row, column)
+		try:
+			isMerged = cellPosition.mergeCells
+		except (COMError, AttributeError):
+			isMerged = False
+		if isMerged:
+			cellPosition = cellPosition.MergeArea(1)
+			cellClass = ExcelMergedCell
+		else:
+			cellClass = ExcelCell
+		cellObj = cellClass(
+			windowHandle=focusCell.windowHandle,
+			excelWindowObject=focusCell.excelWindowObject,
+			excelCellObject=cellPosition,
+		)
+		cellObj.excelCellInfo
+		return cellObj
+	except (AttributeError, COMError):
+		return None
+
+
+def navigateToExcelCell(focusCell: ExcelCell, row: int, column: int) -> ExcelCell | None:
+	cellObj = excelCellAt(focusCell, row, column)
+	if cellObj is None:
+		return None
+	try:
+		cellObj.excelCellObject.Select()
+		cellObj.excelCellObject.Activate()
+		eventHandler.executeEvent("gainFocus", cellObj)
+		return cellObj
+	except (AttributeError, COMError):
+		return None
+
+
+def _cellScopeFormulaText(cellInfo: EXCEL_CELLINFO) -> str | None:
+	if not _isExcelFormula(cellInfo.formula) or not _includeFormulaForCell(isCurrent=True):
+		return None
+	formula = (cellInfo.formula or "").strip()
+	return formula or None
+
+
+def getExcelFormulaDescription(
+	obj: NVDAObject | None,
+	cellInfo: EXCEL_CELLINFO | None,
+	states: set[int] | None,
+	hasFormulaState: int,
+) -> ExcelBrailleResult:
+	if not _conf()["cellFormula"] or obj is None:
+		return ExcelBrailleResult.empty()
+	scope = _scope()
+	if scope.isRowOrColumn:
+		return ExcelBrailleResult.empty()
+	if not cellInfo:
+		return ExcelBrailleResult.empty()
+	if not (states and hasFormulaState in states):
+		return ExcelBrailleResult.empty()
+	formulaText = _cellScopeFormulaText(cellInfo)
+	if not formulaText:
+		return ExcelBrailleResult.empty()
+	return ExcelBrailleResult(formulaText, False, False)
+
+
+_excelCellGetBrailleRegionsInstalled = False
+_originalExcelCellGetBrailleRegions: Any = None
+
+
+class ExcelCellBrailleRegion(braille.NVDAObjectRegion):
+	def __init__(
+		self,
+		obj: NVDAObject,
+		segmentText: str,
+		appendText: str = "",
+		*,
+		isCurrentSegment: bool = False,
+		focusCell: ExcelCell | None = None,
+		row: int = 0,
+		column: int = 0,
+		currentCoords: str | None = None,
+	) -> None:
+		super().__init__(obj, appendText=appendText)
+		self.segmentText = segmentText
+		self.isCurrentSegment = isCurrentSegment
+		self._focusCell = focusCell
+		self._row = row
+		self._column = column
+		if isCurrentSegment and currentCoords:
+			self._contentStart = len(f"{currentCoords}: ")
+		else:
+			self._contentStart = 0
+
+	def update(self) -> None:
+		text = self.segmentText + self.appendText
+		if self.isCurrentSegment:
+			text += _excelHeaderSuffix(self.obj)
+		self.rawText = text
+		self.focusToHardLeft = self.isCurrentSegment
+		braille.Region.update(self)
+
+	def routeTo(self, braillePos: int) -> None:
+		if self.isCurrentSegment:
+			self._routeToCurrentCell(braillePos)
+			return
+		self._routeToNeighborCell()
+
+	def _routeToCurrentCell(self, braillePos: int) -> None:
+		if braille.NVDAObjectHasUsefulText(self.obj):
+			try:
+				textRegion = braille.TextInfoRegion(self.obj)
+				textRegion.update()
+				rawPos = self.brailleToRawPos[braillePos]
+				textOffset = self._rawPosToCellTextOffset(rawPos)
+				if textRegion.rawText:
+					textOffset = min(textOffset, len(textRegion.rawText) - 1)
+				textRegion.routeTo(textRegion.rawToBraillePos[textOffset])
+			except (AttributeError, IndexError, NotImplementedError):
+				log.debugWarning(
+					"Excel TextInfoRegion routing failed",
+					exc_info=True,
+				)
+				self._startInCellEdit()
+			return
+		try:
+			super().routeTo(braillePos)
+		except NotImplementedError:
+			pass
+		self._startInCellEdit()
+
+	def _rawPosToCellTextOffset(self, rawPos: int) -> int:
+		if not self._contentStart:
+			return rawPos
+		return 0 if rawPos < self._contentStart else rawPos - self._contentStart
+
+	@staticmethod
+	def _startInCellEdit() -> None:
+		keyboardHandler.KeyboardInputGesture.fromName("f2").send()
+
+	def _routeToNeighborCell(self) -> None:
+		if self._focusCell is None:
+			return
+		if navigateToExcelCell(self._focusCell, self._row, self._column) is None:
+			log.debugWarning("Excel neighbor routing failed", exc_info=True)
+
+
+def _excelCellBrailleRegionsFromWindow(
+	focusCell: ExcelCell,
+	window: list[EXCEL_CELLINFO],
+) -> list[ExcelCellBrailleRegion]:
+	cellInfo: EXCEL_CELLINFO | None = getattr(focusCell, "excelCellInfo", None)
+	currentCoords = _currentCoords(focusCell, cellInfo)
+	segments = list(iterScopedBrailleSegments(focusCell, window))
+	regions: list[ExcelCellBrailleRegion] = []
+	for segment in segments:
+		regions.append(
+			ExcelCellBrailleRegion(
+				focusCell,
+				segment.text,
+				isCurrentSegment=segment.isCurrent,
+				focusCell=focusCell,
+				row=segment.row,
+				column=segment.column,
+				currentCoords=currentCoords if segment.isCurrent else None,
+			)
+		)
+	return regions
+
+
+def excelCell_getBrailleRegions(
+	obj: ExcelCell,
+	review: bool = False,
+) -> Generator[ExcelCellBrailleRegion, None, None]:
+	window = _getScopedRangeWindow(obj, getattr(obj, "excelCellInfo", None))
+	if review or not isExcelWorksheetCell(obj) or not window:
+		if _originalExcelCellGetBrailleRegions is not None:
+			return _originalExcelCellGetBrailleRegions(obj, review=review)
+		raise NotImplementedError
+	for region in _excelCellBrailleRegionsFromWindow(obj, window):
+		yield region
+
+
+def install_excel_braille_regions() -> None:
+	global _excelCellGetBrailleRegionsInstalled, _originalExcelCellGetBrailleRegions
+	if _excelCellGetBrailleRegionsInstalled:
+		return
+	from NVDAObjects.window.excel import ExcelCell, ExcelMergedCell
+
+	_originalExcelCellGetBrailleRegions = getattr(ExcelCell, "getBrailleRegions", None)
+	ExcelCell.getBrailleRegions = excelCell_getBrailleRegions
+	ExcelMergedCell.getBrailleRegions = excelCell_getBrailleRegions
+	_excelCellGetBrailleRegionsInstalled = True
+	log.debug("Excel row/column braille regions installed")
+
+
+def uninstall_excel_braille_regions() -> None:
+	global _excelCellGetBrailleRegionsInstalled, _originalExcelCellGetBrailleRegions
+	if not _excelCellGetBrailleRegionsInstalled:
+		return
+	from NVDAObjects.window.excel import ExcelCell, ExcelMergedCell
+
+	for cls in (ExcelCell, ExcelMergedCell):
+		if _originalExcelCellGetBrailleRegions is not None:
+			cls.getBrailleRegions = _originalExcelCellGetBrailleRegions
+		else:
+			try:
+				del cls.getBrailleRegions
+			except AttributeError:
+				pass
+	_originalExcelCellGetBrailleRegions = None
+	_excelCellGetBrailleRegionsInstalled = False
+
+
+def sync_excel_braille_regions_patch() -> None:
+	if _conf()["cellFormula"] and _scope().isRowOrColumn:
+		install_excel_braille_regions()
+	else:
+		uninstall_excel_braille_regions()
+
+
+def _excel_focus_object_for_braille() -> NVDAObject | None:
+	obj = api.getFocusObject()
+	if hasattr(obj, "excelCellInfo") or hasattr(obj, "excelCellObject"):
+		return obj
+	for ancestor in api.getFocusAncestors():
+		if hasattr(ancestor, "excelCellInfo") or hasattr(ancestor, "excelCellObject"):
+			return ancestor
+	return None
+
+
+def _partition_braille_buffer_regions(regions: list) -> tuple[list, list]:
+	contextRegions: list = []
+	focusRegions: list = []
+	for region in regions:
+		if getattr(region, "_focusAncestorIndex", None) is not None:
+			contextRegions.append(region)
+		else:
+			focusRegions.append(region)
+	return contextRegions, focusRegions
+
+
+def _excel_primary_focus_region(focusRegions: list) -> Any | None:
+	for region in focusRegions:
+		if getattr(region, "isCurrentSegment", False):
+			return region
+	return focusRegions[-1] if focusRegions else None
+
+
+def _focus_excel_current_at_display_left(
+	handler: braille.BrailleHandler, mainBuffer: braille.BrailleBuffer
+) -> bool:
+	focusRegion = None
+	for region in mainBuffer.regions:
+		if getattr(region, "_focusAncestorIndex", None) is not None:
+			continue
+		if getattr(region, "isCurrentSegment", False):
+			focusRegion = region
+			break
+	if focusRegion is None:
+		for region in reversed(mainBuffer.regions):
+			if getattr(region, "_focusAncestorIndex", None) is None:
+				focusRegion = region
+				break
+	if focusRegion is None:
+		return False
+	for region in mainBuffer.regions:
+		if getattr(region, "_focusAncestorIndex", None) is not None:
+			region.focusToHardLeft = False
+	focusRegion.focusToHardLeft = True
+	try:
+		mainBuffer.focus(focusRegion)
+	except LookupError:
+		log.debugWarning("Excel braille focus placement failed", exc_info=True)
+		return False
+	if handler.buffer is mainBuffer:
+		handler.update()
+	return True
+
+
+def _apply_braille_buffer_focus_regions(
+	handler: braille.BrailleHandler,
+	mainBuffer: braille.BrailleBuffer,
+	contextRegions: list,
+	focusRegions: list,
+) -> bool:
+	for region in contextRegions:
+		region.focusToHardLeft = False
+		region.update()
+	for region in focusRegions:
+		region.update()
+	mainBuffer.regions = contextRegions + focusRegions
+	mainBuffer.update()
+	if not focusRegions:
+		if handler.buffer is mainBuffer:
+			handler.update()
+		return True
+	primaryFocus = _excel_primary_focus_region(focusRegions)
+	if primaryFocus is None:
+		return False
+	for region in focusRegions:
+		region.focusToHardLeft = region is primaryFocus
+	try:
+		mainBuffer.focus(primaryFocus)
+	except LookupError:
+		log.debugWarning("Excel braille focus placement failed", exc_info=True)
+		return False
+	if handler.buffer is mainBuffer:
+		handler.update()
+	return True
+
+
+def _build_excel_focus_regions(focus: NVDAObject) -> list:
+	window = _getScopedRangeWindow(focus, getattr(focus, "excelCellInfo", None))
+	if _conf()["cellFormula"] and _scope().isRowOrColumn and window:
+		regions = _excelCellBrailleRegionsFromWindow(focus, window)
+		for region in regions:
+			region.update()
+		return regions
+	region = braille.NVDAObjectRegion(focus)
+	region.focusToHardLeft = True
+	region.update()
+	return [region]
+
+
+def refresh_excel_braille_display() -> None:
+	handler = braille.handler
+	if handler is None or not handler.enabled:
+		return
+	focus = _excel_focus_object_for_braille()
+	if focus is None:
+		return
+	sync_excel_braille_regions_patch()
+	clear_scoped_braille_cache(focus)
+	focus.invalidateCache()
+	if handler.buffer is not handler.mainBuffer:
+		handler.buffer = handler.mainBuffer
+	mainBuffer = handler.mainBuffer
+	oldRegions = list(mainBuffer.regions)
+	contextRegions, focusRegions = _partition_braille_buffer_regions(oldRegions)
+	scopedWindow = (
+		_getScopedRangeWindow(focus, getattr(focus, "excelCellInfo", None))
+		if _conf()["cellFormula"] and _scope().isRowOrColumn
+		else None
+	)
+	wasScopedLine = bool(focusRegions) and isinstance(focusRegions[0], ExcelCellBrailleRegion)
+	wantsScopedLine = scopedWindow is not None
+
+	if wantsScopedLine == wasScopedLine:
+		if wantsScopedLine:
+			newFocusRegions = _build_excel_focus_regions(focus)
+			if newFocusRegions and _apply_braille_buffer_focus_regions(
+				handler, mainBuffer, contextRegions, newFocusRegions
+			):
+				return
+		elif len(focusRegions) == 1:
+			focusRegions[0].focusToHardLeft = True
+			focusRegions[0].update()
+			if _apply_braille_buffer_focus_regions(handler, mainBuffer, contextRegions, focusRegions):
+				return
+
+	if contextRegions:
+		newFocusRegions = _build_excel_focus_regions(focus)
+		if newFocusRegions and _apply_braille_buffer_focus_regions(
+			handler, mainBuffer, contextRegions, newFocusRegions
+		):
+			return
+
+	regionObj = focus
+	treeInterceptor = getattr(focus, "treeInterceptor", None)
+	if treeInterceptor is not None and not treeInterceptor.passThrough and treeInterceptor.isReady:
+		regionObj = treeInterceptor
+	handler._doNewObject(
+		itertools.chain(
+			braille.getFocusContextRegions(regionObj, oldFocusRegions=oldRegions),
+			braille.getFocusRegions(regionObj),
+		)
+	)
+	if wantsScopedLine and not _focus_excel_current_at_display_left(handler, mainBuffer):
+		if mainBuffer.regions:
+			try:
+				mainBuffer.focus(mainBuffer.regions[-1])
+				if handler.buffer is mainBuffer:
+					handler.update()
+			except LookupError:
+				log.debugWarning("Excel braille fallback focus failed", exc_info=True)
+
+
+_headerTextGuardsInstalled = False
+_originalGetRowHeaderText: Any = None
+_originalGetColumnHeaderText: Any = None
+
+
+def _excelCellCoordinatesReady(cell: ExcelCell) -> bool:
+	info = cell.excelCellInfo
+	if info is None:
+		return False
+	rowNumber = info.rowNumber
+	columnNumber = info.columnNumber
+	return isinstance(rowNumber, int) and isinstance(columnNumber, int)
+
+
+def _safeGetRowHeaderText(self: ExcelCell) -> str | None:
+	if not _excelCellCoordinatesReady(self):
+		return None
+	try:
+		return _originalGetRowHeaderText(self)
+	except (TypeError, ValueError, COMError):
+		log.debugWarning("Excel row header text lookup failed", exc_info=True)
+		return None
+
+
+def _safeGetColumnHeaderText(self: ExcelCell) -> str | None:
+	if not _excelCellCoordinatesReady(self):
+		return None
+	try:
+		return _originalGetColumnHeaderText(self)
+	except (TypeError, ValueError, COMError):
+		log.debugWarning("Excel column header text lookup failed", exc_info=True)
+		return None
+
+
+def install_excel_header_text_guards() -> None:
+	global _headerTextGuardsInstalled, _originalGetRowHeaderText, _originalGetColumnHeaderText
+	from NVDAObjects.window.excel import ExcelCell, ExcelMergedCell
+
+	if ExcelCell._get_rowHeaderText is _safeGetRowHeaderText:
+		_headerTextGuardsInstalled = True
+		return
+	_originalGetRowHeaderText = ExcelCell._get_rowHeaderText
+	_originalGetColumnHeaderText = ExcelCell._get_columnHeaderText
+	for cls in (ExcelCell, ExcelMergedCell):
+		cls._get_rowHeaderText = _safeGetRowHeaderText
+		cls._get_columnHeaderText = _safeGetColumnHeaderText
+	_headerTextGuardsInstalled = True
+
+
+def uninstall_excel_header_text_guards() -> None:
+	global _headerTextGuardsInstalled, _originalGetRowHeaderText, _originalGetColumnHeaderText
+	if not _headerTextGuardsInstalled:
+		return
+	from NVDAObjects.window.excel import ExcelCell, ExcelMergedCell
+
+	for cls in (ExcelCell, ExcelMergedCell):
+		if _originalGetRowHeaderText is not None:
+			cls._get_rowHeaderText = _originalGetRowHeaderText
+		if _originalGetColumnHeaderText is not None:
+			cls._get_columnHeaderText = _originalGetColumnHeaderText
+	_originalGetRowHeaderText = None
+	_originalGetColumnHeaderText = None
+	_headerTextGuardsInstalled = False
+
+
+class AppModule(_NVDAExcelAppModule):
+	scriptCategory = addonName
+
+	def event_gainFocus(self, obj, nextHandler):
+		nextHandler()
+		if not _conf()["cellFormula"] or not _scope().isRowOrColumn:
+			return
+		focus = _excel_focus_object_for_braille()
+		if focus is None:
+			return
+		if not usesScopedBrailleRegions(focus):
+			return
+		handler = braille.handler
+		if handler is None or not handler.enabled or handler.buffer is not handler.mainBuffer:
+			return
+		_focus_excel_current_at_display_left(handler, handler.mainBuffer)
+
+	@script(
+		description=_(
+			"Cycle how Microsoft Excel cell formulas are shown in braille (current cell, row, or column)"
+		),
+	)
+	def script_cycleExcelFormulaScope(self, gesture):
+		if not _conf()["cellFormula"]:
+			speakMessage(
+				_(
+					"Report cell formulas in braille is disabled. "
+					"Enable it in Braille Extender settings, Excel."
+				)
+			)
+			return
+		new_scope = cycle_formula_scope()
+		clear_scoped_braille_cache()
+		refresh_excel_braille_display()
+		speakMessage(new_scope.label)

--- a/addon/globalPlugins/brailleExtender/__init__.py
+++ b/addon/globalPlugins/brailleExtender/__init__.py
@@ -10,6 +10,7 @@ import time
 from collections import OrderedDict
 
 import addonHandler
+import appModuleHandler
 import api
 import braille
 import brailleInput
@@ -145,6 +146,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def __init__(self):
 		startTime = time.time()
 		super(globalPluginHandler.GlobalPlugin, self).__init__()
+		appModuleHandler.registerExecutableWithAppModule("excel", "brailleExtenderExcel")
 		patches.instanceGP = self
 		patches.apply_patches()
 		braille.TextInfoRegion._addTextWithFields = documentformatting.decorator(
@@ -1611,6 +1613,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def terminate(self):
 		from .custom_braille_tables import ensure_nvda_braille_config_valid
 
+		appModuleHandler.unregisterExecutable("excel")
 		ensure_nvda_braille_config_valid()
 		self.removeMenu()
 		rolelabels.discardRoleLabels()

--- a/addon/globalPlugins/brailleExtender/addoncfg.py
+++ b/addon/globalPlugins/brailleExtender/addoncfg.py
@@ -123,6 +123,18 @@ def getValidBrailleDisplayPrefered():
 	return displays
 
 
+def _excelConfspec() -> dict[str, str]:
+	from appModules.brailleExtenderExcel import FormulaScope, ScopeFormulaDisplay
+
+	return {
+		"cellFormula": "boolean(default=True)",
+		"cellFormulaScope": f"option({', '.join(s.value for s in FormulaScope)}, default={FormulaScope.CELL})",
+		"scopeFormulaDisplay": f"option({', '.join(s.value for s in ScopeFormulaDisplay)}, default={ScopeFormulaDisplay.ACTIVE_CELL})",
+		"cellFormulaNeighbors": "integer(min=0, max=50, default=9)",
+		"cellFormulaSeparator": "string(default=' | ')",
+	}
+
+
 def getConfspec():
 	global curBD
 	curBD = braille.handler.display.name
@@ -231,7 +243,6 @@ def getConfspec():
 				"center": f"option({CHOICE_none}, {CHOICE_linePad}, {CHOICE_dot7}, {CHOICE_dot8}, {CHOICE_dots78}, {CHOICE_spacing}, {CHOICE_tags}, default={CHOICE_tags})",
 				"justified": f"option({CHOICE_none}, {CHOICE_linePad}, {CHOICE_dot7}, {CHOICE_dot8}, {CHOICE_dots78}, {CHOICE_spacing}, {CHOICE_tags}, default={CHOICE_tags})",
 			},
-			"cellFormula": "boolean(default=True)",
 			"methods": {
 				"bold": f"option({CHOICE_none}, {CHOICE_dot7}, {CHOICE_dot8}, {CHOICE_dots78}, {CHOICE_tags}, default={CHOICE_tags})",
 				"italic": f"option({CHOICE_none}, {CHOICE_dot7}, {CHOICE_dot8}, {CHOICE_dots78}, {CHOICE_tags}, default={CHOICE_tags})",
@@ -323,6 +334,7 @@ def getConfspec():
 			"fixCursorPositions": "boolean(default=True)",
 			"refreshForegroundObjNameChange": "boolean(default=False)",
 		},
+		"excel": _excelConfspec(),
 	}
 
 
@@ -388,6 +400,20 @@ def loadPreferredTables() -> None:
 	sync_preferred_table_lists()
 
 
+def _migrate_excel_settings_from_document_formatting() -> None:
+	be = config.conf["brailleExtender"]
+	df = be.get("documentFormatting")
+	if df is None or "cellFormula" not in df:
+		return
+	excel = be.setdefault("excel", {})
+	if "cellFormula" not in excel:
+		excel["cellFormula"] = df["cellFormula"]
+	try:
+		del df["cellFormula"]
+	except KeyError:
+		pass
+
+
 def loadConf():
 	global curBD, gesturesFileExists, profileFileExists, iniProfile
 	curBD = braille.handler.display.name
@@ -398,6 +424,7 @@ def loadConf():
 	except configobj.validate.VdtValueError:
 		config.conf["brailleExtender"]["updateChannel"] = "dev"
 		brlextConf = config.conf["brailleExtender"].copy()
+	_migrate_excel_settings_from_document_formatting()
 	if "profile_%s" % curBD not in brlextConf.keys():
 		config.conf["brailleExtender"]["profile_%s" % curBD] = "default"
 	if "tabSize_%s" % curBD not in brlextConf.keys():

--- a/addon/globalPlugins/brailleExtender/addoncfg.py
+++ b/addon/globalPlugins/brailleExtender/addoncfg.py
@@ -132,6 +132,8 @@ def _excelConfspec() -> dict[str, str]:
 		"scopeFormulaDisplay": f"option({', '.join(s.value for s in ScopeFormulaDisplay)}, default={ScopeFormulaDisplay.ACTIVE_CELL})",
 		"cellFormulaNeighbors": "integer(min=0, max=50, default=9)",
 		"cellFormulaSeparator": "string(default=' | ')",
+		"rowAxisPrefix": "string(default='')",
+		"columnAxisPrefix": "string(default='')",
 	}
 
 

--- a/addon/globalPlugins/brailleExtender/autoscroll.py
+++ b/addon/globalPlugins/brailleExtender/autoscroll.py
@@ -70,10 +70,13 @@ def get_dynamic_auto_scroll_delay(buffer=None):
 	return get_auto_scroll_delay()
 
 
-def get_auto_scroll_delay():
+def get_auto_scroll_delay() -> int:
 	key = f"delay_{braille.handler.display.name}"
 	if key in conf:
-		return conf[key]
+		try:
+			return int(conf[key])
+		except (TypeError, ValueError):
+			pass
 	return DEFAULT_AUTO_SCROLL_DELAY
 
 
@@ -130,7 +133,7 @@ class SettingsDlg(gui.settingsDialogs.SettingsPanel):
 			gui.nvdaControls.SelectOnFocusSpinCtrl,
 			min=MIN_AUTO_SCROLL_DELAY,
 			max=MAX_AUTO_SCROLL_DELAY,
-			initial=get_auto_scroll_delay(),
+			initial=int(get_auto_scroll_delay()),
 		)
 		# Translators: label of a dialog.
 		label = _("&Step for delay change (ms):")
@@ -139,7 +142,7 @@ class SettingsDlg(gui.settingsDialogs.SettingsPanel):
 			gui.nvdaControls.SelectOnFocusSpinCtrl,
 			min=MIN_STEP_DELAY_CHANGE,
 			max=MAX_STEP_DELAY_CHANGE,
-			initial=conf["stepDelayChange"],
+			initial=int(conf["stepDelayChange"]),
 		)
 		# Translators: label of a dialog.
 		label = _("&Adjust the delay to content")

--- a/addon/globalPlugins/brailleExtender/braille_terminal.py
+++ b/addon/globalPlugins/brailleExtender/braille_terminal.py
@@ -33,7 +33,7 @@ def _object_below_lock_screen(obj: Any) -> bool:
 	except ImportError:
 		return False
 	except Exception:
-		log.debugWarning("BrailleExtender: could not evaluate lock screen state", exc_info=True)
+		log.debugWarning("could not evaluate lock screen state", exc_info=True)
 		return True
 
 
@@ -90,7 +90,7 @@ def _sync_review_position_to_object_caret(obj: Any) -> None:
 			info = obj.makeTextInfo(textInfos.POSITION_FIRST)
 		except Exception:
 			log.debugWarning(
-				"BrailleExtender: cannot obtain TextInfo to sync review in terminal",
+				"cannot obtain TextInfo to sync review in terminal",
 				exc_info=True,
 			)
 			return
@@ -98,7 +98,7 @@ def _sync_review_position_to_object_caret(obj: Any) -> None:
 		info.collapse()
 		api.setReviewPosition(info)
 	except Exception:
-		log.debugWarning("BrailleExtender: setReviewPosition for terminal failed", exc_info=True)
+		log.debugWarning("setReviewPosition for terminal failed", exc_info=True)
 
 
 def _restore_tether_after_terminal(handler: Any) -> None:

--- a/addon/globalPlugins/brailleExtender/documentformatting.py
+++ b/addon/globalPlugins/brailleExtender/documentformatting.py
@@ -683,7 +683,7 @@ class ManageMethods(wx.Dialog):
 		try:
 			return list(CHOICES_LABELS.keys()).index(conf["methods"].get(attribute, CHOICE_none))
 		except ValueError:
-			log.debugWarning("BrailleExtender: unknown formatting method %r", attribute)
+			log.debugWarning("unknown formatting method %r", attribute)
 			return 0
 
 	def onOk(self, evt):
@@ -789,10 +789,6 @@ class SettingsDlg(gui.settingsDialogs.SettingsPanel):
 			)
 			self.dynamic_options[-1].SetSelection(keys.index(get_report(key, 0)))
 
-		label = _("Cell &formula (Excel only for now)")
-		self.cellFormula = sHelper.addItem(wx.CheckBox(self, label=label))
-		self.cellFormula.SetValue(conf["cellFormula"])
-
 		label = _("Le&vel of items in a nested list")
 		self.levelItemsList = sHelper.addItem(wx.CheckBox(self, label=label))
 		self.levelItemsList.SetValue(conf["lists"]["showLevelItem"])
@@ -825,4 +821,3 @@ class SettingsDlg(gui.settingsDialogs.SettingsPanel):
 		for i, key in enumerate(LABELS_REPORTS.keys()):
 			val = list(LABELS_STATES.keys())[self.dynamic_options[i].GetSelection()]
 			set_report(key, val)
-		conf["cellFormula"] = self.cellFormula.IsChecked()

--- a/addon/globalPlugins/brailleExtender/excelSettings.py
+++ b/addon/globalPlugins/brailleExtender/excelSettings.py
@@ -90,12 +90,11 @@ class SettingsDlg(gui.settingsDialogs.SettingsPanel):
 		self.cellFormulaSeparator.Enable(rowCol)
 
 	def onSave(self) -> None:
-		from appModules.brailleExtenderExcel import clear_scoped_braille_cache, refresh_excel_braille_display
+		from appModules.brailleExtenderExcel import schedule_excel_braille_refresh
 
 		conf["cellFormula"] = self.cellFormula.IsChecked()
-		conf["cellFormulaScope"] = list(FormulaScope)[self.cellFormulaScope.GetSelection()]
-		conf["scopeFormulaDisplay"] = list(ScopeFormulaDisplay)[self.scopeFormulaDisplay.GetSelection()]
-		conf["cellFormulaNeighbors"] = self.cellFormulaNeighbors.GetValue()
+		conf["cellFormulaScope"] = list(FormulaScope)[self.cellFormulaScope.GetSelection()].value
+		conf["scopeFormulaDisplay"] = list(ScopeFormulaDisplay)[self.scopeFormulaDisplay.GetSelection()].value
+		conf["cellFormulaNeighbors"] = int(self.cellFormulaNeighbors.GetValue())
 		conf["cellFormulaSeparator"] = self.cellFormulaSeparator.GetValue()
-		clear_scoped_braille_cache()
-		refresh_excel_braille_display()
+		schedule_excel_braille_refresh()

--- a/addon/globalPlugins/brailleExtender/excelSettings.py
+++ b/addon/globalPlugins/brailleExtender/excelSettings.py
@@ -14,18 +14,18 @@ addonHandler.initTranslation()
 
 conf = config.conf["brailleExtender"]["excel"]
 
-# Translators: when to show formulas in row/column scope (Braille Extender Excel settings).
+# Translators: formula display when Braille view is entire row or column (Braille Extender Excel settings).
 _SCOPE_FORMULA_LABELS = {
-	ScopeFormulaDisplay.ACTIVE_CELL: _("Active cell only"),
-	ScopeFormulaDisplay.ALL: _("All cells in range"),
-	ScopeFormulaDisplay.NONE: _("Values only (hide formulas)"),
+	ScopeFormulaDisplay.ACTIVE_CELL: _("Focused cell only"),
+	ScopeFormulaDisplay.ALL: _("Every cell on the line"),
+	ScopeFormulaDisplay.NONE: _("Values only (no formulas)"),
 }
 
 
 class SettingsDlg(gui.settingsDialogs.SettingsPanel):
 	# Translators: title of the Excel category in Braille Extender settings.
 	title = _("Excel")
-	panelDescription = _("Options for reporting Microsoft Excel cell formulas in braille.")
+	panelDescription = _("Choose how Microsoft Excel cells and formulas appear on the braille display.")
 
 	def makeSettings(self, settingsSizer: wx.Sizer) -> None:
 		sHelper = gui.guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
@@ -36,7 +36,7 @@ class SettingsDlg(gui.settingsDialogs.SettingsPanel):
 		self.cellFormula.Bind(wx.EVT_CHECKBOX, self._onChanged)
 
 		self.cellFormulaScope = sHelper.addLabeledControl(
-			_("Formula &scope:"),
+			_("Braille &view:"),
 			wx.Choice,
 			choices=[SCOPE_LABELS[scope] for scope in FormulaScope],
 		)
@@ -49,7 +49,7 @@ class SettingsDlg(gui.settingsDialogs.SettingsPanel):
 		self.cellFormulaScope.Bind(wx.EVT_CHOICE, self._onChanged)
 
 		self.scopeFormulaDisplay = sHelper.addLabeledControl(
-			_("Show &formulas in row/column scope:"),
+			_("Formulas on row or column &line:"),
 			wx.Choice,
 			choices=[_SCOPE_FORMULA_LABELS[mode] for mode in ScopeFormulaDisplay],
 		)
@@ -62,14 +62,14 @@ class SettingsDlg(gui.settingsDialogs.SettingsPanel):
 		self.scopeFormulaDisplay.Bind(wx.EVT_CHOICE, self._onChanged)
 
 		self.cellFormulaNeighbors = sHelper.addLabeledControl(
-			_("Number of cells before and after (row/column scope):"),
+			_("Cells on each side of focus (&row/column line):"),
 			gui.nvdaControls.SelectOnFocusSpinCtrl,
 			min=0,
 			max=50,
 			initial=int(conf["cellFormulaNeighbors"]),
 		)
 		self.cellFormulaSeparator = sHelper.addLabeledControl(
-			_("Cell &separator (row/column scope):"),
+			_("&Separator between cells on the line:"),
 			wx.TextCtrl,
 		)
 		self.cellFormulaSeparator.SetValue(conf["cellFormulaSeparator"])

--- a/addon/globalPlugins/brailleExtender/excelSettings.py
+++ b/addon/globalPlugins/brailleExtender/excelSettings.py
@@ -14,7 +14,7 @@ addonHandler.initTranslation()
 
 conf = config.conf["brailleExtender"]["excel"]
 
-# Translators: formula display when Braille view is entire row or column (Braille Extender Excel settings).
+# Translators: formula display when Braille view is row or column range (Braille Extender Excel settings).
 _SCOPE_FORMULA_LABELS = {
 	ScopeFormulaDisplay.ACTIVE_CELL: _("Focused cell only"),
 	ScopeFormulaDisplay.ALL: _("Every cell on the line"),

--- a/addon/globalPlugins/brailleExtender/excelSettings.py
+++ b/addon/globalPlugins/brailleExtender/excelSettings.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+# excelSettings.py
+# Part of BrailleExtender addon for NVDA
+# Copyright 2026 André-Abush Clause, released under GPL.
+
+import addonHandler
+import config
+import gui
+import wx
+
+from appModules.brailleExtenderExcel import FormulaScope, SCOPE_LABELS, ScopeFormulaDisplay
+
+addonHandler.initTranslation()
+
+conf = config.conf["brailleExtender"]["excel"]
+
+# Translators: when to show formulas in row/column scope (Braille Extender Excel settings).
+_SCOPE_FORMULA_LABELS = {
+	ScopeFormulaDisplay.ACTIVE_CELL: _("Active cell only"),
+	ScopeFormulaDisplay.ALL: _("All cells in range"),
+	ScopeFormulaDisplay.NONE: _("Values only (hide formulas)"),
+}
+
+
+class SettingsDlg(gui.settingsDialogs.SettingsPanel):
+	# Translators: title of the Excel category in Braille Extender settings.
+	title = _("Excel")
+	panelDescription = _("Options for reporting Microsoft Excel cell formulas in braille.")
+
+	def makeSettings(self, settingsSizer: wx.Sizer) -> None:
+		sHelper = gui.guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+		sHelper.addItem(wx.StaticText(self, label=self.panelDescription))
+
+		self.cellFormula = sHelper.addItem(wx.CheckBox(self, label=_("Report cell &formulas in braille")))
+		self.cellFormula.SetValue(conf["cellFormula"])
+		self.cellFormula.Bind(wx.EVT_CHECKBOX, self._onChanged)
+
+		self.cellFormulaScope = sHelper.addLabeledControl(
+			_("Formula &scope:"),
+			wx.Choice,
+			choices=[SCOPE_LABELS[scope] for scope in FormulaScope],
+		)
+		try:
+			self.cellFormulaScope.SetSelection(
+				list(FormulaScope).index(FormulaScope(conf["cellFormulaScope"]))
+			)
+		except ValueError:
+			self.cellFormulaScope.SetSelection(0)
+		self.cellFormulaScope.Bind(wx.EVT_CHOICE, self._onChanged)
+
+		self.scopeFormulaDisplay = sHelper.addLabeledControl(
+			_("Show &formulas in row/column scope:"),
+			wx.Choice,
+			choices=[_SCOPE_FORMULA_LABELS[mode] for mode in ScopeFormulaDisplay],
+		)
+		try:
+			self.scopeFormulaDisplay.SetSelection(
+				list(ScopeFormulaDisplay).index(ScopeFormulaDisplay(conf["scopeFormulaDisplay"]))
+			)
+		except ValueError:
+			self.scopeFormulaDisplay.SetSelection(0)
+		self.scopeFormulaDisplay.Bind(wx.EVT_CHOICE, self._onChanged)
+
+		self.cellFormulaNeighbors = sHelper.addLabeledControl(
+			_("Number of cells before and after (row/column scope):"),
+			gui.nvdaControls.SelectOnFocusSpinCtrl,
+			min=0,
+			max=50,
+			initial=int(conf["cellFormulaNeighbors"]),
+		)
+		self.cellFormulaSeparator = sHelper.addLabeledControl(
+			_("Cell &separator (row/column scope):"),
+			wx.TextCtrl,
+		)
+		self.cellFormulaSeparator.SetValue(conf["cellFormulaSeparator"])
+		self._onChanged()
+
+	def _rowOrColumnScope(self) -> bool:
+		if not self.cellFormula.IsChecked():
+			return False
+		selection = self.cellFormulaScope.GetSelection()
+		return 0 <= selection < len(FormulaScope) and list(FormulaScope)[selection].isRowOrColumn
+
+	def _onChanged(self, evt: wx.CommandEvent | None = None) -> None:
+		enabled = self.cellFormula.IsChecked()
+		self.cellFormulaScope.Enable(enabled)
+		rowCol = self._rowOrColumnScope()
+		self.scopeFormulaDisplay.Enable(enabled and rowCol)
+		self.cellFormulaNeighbors.Enable(rowCol)
+		self.cellFormulaSeparator.Enable(rowCol)
+
+	def onSave(self) -> None:
+		from appModules.brailleExtenderExcel import clear_scoped_braille_cache, refresh_excel_braille_display
+
+		conf["cellFormula"] = self.cellFormula.IsChecked()
+		conf["cellFormulaScope"] = list(FormulaScope)[self.cellFormulaScope.GetSelection()]
+		conf["scopeFormulaDisplay"] = list(ScopeFormulaDisplay)[self.scopeFormulaDisplay.GetSelection()]
+		conf["cellFormulaNeighbors"] = self.cellFormulaNeighbors.GetValue()
+		conf["cellFormulaSeparator"] = self.cellFormulaSeparator.GetValue()
+		clear_scoped_braille_cache()
+		refresh_excel_braille_display()

--- a/addon/globalPlugins/brailleExtender/excelSettings.py
+++ b/addon/globalPlugins/brailleExtender/excelSettings.py
@@ -73,6 +73,23 @@ class SettingsDlg(gui.settingsDialogs.SettingsPanel):
 			wx.TextCtrl,
 		)
 		self.cellFormulaSeparator.SetValue(conf["cellFormulaSeparator"])
+
+		# Translators: Label for the custom text shown at the start of an Excel row-range braille line.
+		self.rowAxisPrefix = sHelper.addLabeledControl(_("&Row line prefix:"), wx.TextCtrl)
+		self.rowAxisPrefix.SetValue(conf["rowAxisPrefix"])
+		# Translators: Label for the custom text shown at the start of an Excel column-range braille line.
+		self.columnAxisPrefix = sHelper.addLabeledControl(_("&Column line prefix:"), wx.TextCtrl)
+		self.columnAxisPrefix.SetValue(conf["columnAxisPrefix"])
+		# Translators: Hint under the row/column line prefix fields in Braille Extender Excel settings.
+		sHelper.addItem(
+			wx.StaticText(
+				self,
+				label=_(
+					"Leave empty to use the translated default. "
+					"Do not type a space at the end; one space is added automatically before the cell address."
+				),
+			)
+		)
 		self._onChanged()
 
 	def _rowOrColumnScope(self) -> bool:
@@ -88,6 +105,8 @@ class SettingsDlg(gui.settingsDialogs.SettingsPanel):
 		self.scopeFormulaDisplay.Enable(enabled and rowCol)
 		self.cellFormulaNeighbors.Enable(rowCol)
 		self.cellFormulaSeparator.Enable(rowCol)
+		self.rowAxisPrefix.Enable(rowCol)
+		self.columnAxisPrefix.Enable(rowCol)
 
 	def onSave(self) -> None:
 		from appModules.brailleExtenderExcel import schedule_excel_braille_refresh
@@ -97,4 +116,6 @@ class SettingsDlg(gui.settingsDialogs.SettingsPanel):
 		conf["scopeFormulaDisplay"] = list(ScopeFormulaDisplay)[self.scopeFormulaDisplay.GetSelection()].value
 		conf["cellFormulaNeighbors"] = int(self.cellFormulaNeighbors.GetValue())
 		conf["cellFormulaSeparator"] = self.cellFormulaSeparator.GetValue()
+		conf["rowAxisPrefix"] = self.rowAxisPrefix.GetValue().strip()
+		conf["columnAxisPrefix"] = self.columnAxisPrefix.GetValue().strip()
 		schedule_excel_braille_refresh()

--- a/addon/globalPlugins/brailleExtender/objectpresentation.py
+++ b/addon/globalPlugins/brailleExtender/objectpresentation.py
@@ -14,11 +14,13 @@ import controlTypes
 import queueHandler
 import ui
 from logHandler import log
+from NVDAHelper.localLib import EXCEL_CELLINFO
 from NVDAObjects.behaviors import ProgressBar
 
 from . import addoncfg
 from .common import N_, CHOICE_liblouis, CHOICE_none, ADDON_ORDER_PROPERTIES, IS_CURRENT_NO
 from .documentformatting import CHOICES_LABELS, get_report, LABELS_STATES
+from appModules.brailleExtenderExcel import ExcelBrailleResult, getExcelFormulaDescription
 from .utils import get_output_reason, get_control_type
 
 addonHandler.initTranslation()
@@ -95,42 +97,61 @@ def update_NVDAObjectRegion(self):
 	placeholderValue = obj.placeholder
 	if placeholderValue and not obj._isTextEmpty:
 		placeholderValue = None
-	cellInfo = None
-	if hasattr(obj, "excelCellInfo"):
-		cellInfo = obj.excelCellInfo
+	isExcelCell = hasattr(obj, "excelCellInfo")
+	cellInfo: EXCEL_CELLINFO | None = obj.excelCellInfo if isExcelCell else None
+	excelBraille: ExcelBrailleResult = getExcelFormulaDescription(
+		obj,
+		cellInfo,
+		obj.states,
+		get_control_type("STATE_HASFORMULA"),
+	)
+	if isExcelCell:
+		cellValue = None
+	elif excelBraille.suppress_name:
+		cellValue = None
+	else:
+		cellValue = obj.value if not braille.NVDAObjectHasUsefulText(obj) else None
 	text = getPropertiesBraille(
-		name=obj.name,
+		name=None if excelBraille.suppress_name else obj.name,
 		role=role,
 		roleText=obj.roleTextBraille,
 		current=obj.isCurrent,
 		placeholder=placeholderValue,
-		value=obj.value if not braille.NVDAObjectHasUsefulText(obj) else None,
+		value=cellValue,
 		states=obj.states,
-		description=obj.description if presConfig["reportObjectDescriptions"] else None,
+		description=(
+			excelBraille.description
+			if excelBraille.description
+			else (obj.description if presConfig["reportObjectDescriptions"] else None)
+		),
 		keyboardShortcut=obj.keyboardShortcut if presConfig["reportKeyboardShortcuts"] else None,
 		positionInfo=obj.positionInfo if presConfig["reportObjectPositionInformation"] else None,
-		cellCoordsText=obj.cellCoordsText if get_report("tableCellCoords") else None,
-		cellInfo=cellInfo,
+		cellCoordsText=None
+		if excelBraille.suppress_coords
+		else (obj.cellCoordsText if get_report("tableCellCoords") else None),
+		formulaDescriptionSet=bool(excelBraille.description),
+		suppressCellName=excelBraille.suppress_name,
 	)
-	try:
-		if getattr(obj, "columnHeaderText"):
-			text += "⣀" + obj.columnHeaderText
-	except NotImplementedError:
-		pass
-	try:
-		if getattr(obj, "rowHeaderText"):
-			text += "⡀" + obj.rowHeaderText
-	except NotImplementedError:
-		pass
-	if not getattr(obj, "cellCoordsText"):
+	if isExcelCell and cellInfo:
+		try:
+			if getattr(obj, "columnHeaderText"):
+				text += "⣀" + obj.columnHeaderText
+		except (NotImplementedError, TypeError):
+			pass
+		try:
+			if getattr(obj, "rowHeaderText"):
+				text += "⡀" + obj.rowHeaderText
+		except (NotImplementedError, TypeError):
+			pass
+	if not excelBraille.suppress_coords and not getattr(obj, "cellCoordsText", None):
 		coordinates = ""
 		try:
-			if getattr(obj, "rowNumber"):
+			if getattr(obj, "rowNumber", None):
 				coordinates += N_("r{rowNumber}").format(rowNumber=obj.rowNumber)
 		except NotImplementedError:
 			pass
 		try:
-			if getattr(obj, "columnNumber"):
+			if getattr(obj, "columnNumber", None):
 				coordinates += N_("c{columnNumber}").format(columnNumber=obj.columnNumber)
 		except NotImplementedError:
 			pass
@@ -177,7 +198,10 @@ def getPropertiesBraille(**propertyValues) -> str:
 	negativeStateLabels = braille.negativeStateLabels
 	TEXT_SEPARATOR = braille.TEXT_SEPARATOR
 	roleLabels = braille.roleLabels
+	suppressName = propertyValues.get("suppressCellName")
 	name = propertyValues.get("name")
+	if suppressName:
+		name = None
 	if name:
 		properties["name"] = name
 	description = propertyValues.get("description")
@@ -188,7 +212,6 @@ def getPropertiesBraille(**propertyValues) -> str:
 	positionInfo = propertyValues.get("positionInfo")
 	level = positionInfo.get("level") if positionInfo else None
 	cellCoordsText = propertyValues.get("cellCoordsText")
-	cellInfo = propertyValues.get("cellInfo")
 	rowNumber = propertyValues.get("rowNumber")
 	columnNumber = propertyValues.get("columnNumber")
 	# When fetching row and column span
@@ -207,18 +230,10 @@ def getPropertiesBraille(**propertyValues) -> str:
 			states = states.copy()
 			states.discard(get_control_type("STATE_VISITED"))
 			roleText = N_("vlnk")
-		elif (
-			not description
-			and config.conf["brailleExtender"]["documentFormatting"]["cellFormula"]
-			and states
-			and get_control_type("STATE_HASFORMULA") in states
-			and cellInfo
-			and hasattr(cellInfo, "formula")
-			and cellInfo.formula
-		):
-			states = states.copy()
-			states.discard(get_control_type("STATE_HASFORMULA"))
-			description = cellInfo.formula
+		elif propertyValues.get("formulaDescriptionSet"):
+			if states:
+				states = states.copy()
+				states.discard(get_control_type("STATE_HASFORMULA"))
 		elif (
 			name or cellCoordsText or rowNumber or columnNumber
 		) and role in controlTypes.silentRolesOnFocus:
@@ -231,7 +246,12 @@ def getPropertiesBraille(**propertyValues) -> str:
 		roleText += roleTextPost
 	if roleText:
 		properties["roleText"] = roleText
-	value = propertyValues.get("value") if role not in controlTypes.silentValuesForRoles else None
+	if suppressName:
+		value = None
+	elif role not in controlTypes.silentValuesForRoles:
+		value = propertyValues.get("value")
+	else:
+		value = None
 	if value:
 		properties["value"] = value
 	if states:

--- a/addon/globalPlugins/brailleExtender/patches.py
+++ b/addon/globalPlugins/brailleExtender/patches.py
@@ -110,7 +110,7 @@ def _stop_nvda_core_autoscroll() -> None:
 	try:
 		auto_scroll(enable=False)
 	except Exception:
-		log.debugWarning("BrailleExtender: could not disable NVDA core auto scroll", exc_info=True)
+		log.debugWarning("could not disable NVDA core auto scroll", exc_info=True)
 
 
 def _saveOriginals():
@@ -538,7 +538,7 @@ def _prepare_format_field_for_braille(field: dict[str, Any]) -> None:
 
 		normalizeIA2TextFormatField(field)
 	except Exception:
-		log.debugWarning("BrailleExtender: normalizeIA2TextFormatField failed", exc_info=True)
+		log.debugWarning("normalizeIA2TextFormatField failed", exc_info=True)
 
 
 def _text_position_matches_bucket(raw: Any, want: str) -> bool:
@@ -605,14 +605,12 @@ def _try_append_nvda_core_formatting_markers(
 			if not marker.shouldBeUsed(key):
 				continue
 		except Exception:
-			log.debugWarning("BrailleExtender: NVDA marker shouldBeUsed failed for %s", key, exc_info=True)
+			log.debugWarning("NVDA marker shouldBeUsed failed for %s", key, exc_info=True)
 			continue
 		try:
 			append_fn(key, marker, parts, field, fieldCache)
 		except Exception:
-			log.debugWarning(
-				"BrailleExtender: NVDA _appendFormattingMarker failed for %s", key, exc_info=True
-			)
+			log.debugWarning("NVDA _appendFormattingMarker failed for %s", key, exc_info=True)
 	if not parts:
 		# NVDA did not emit any markers; allow ``getFormatFieldBraille`` fallbacks (e.g. tags when
 		# attributes are delegated to NVDA core but markers are empty).
@@ -676,7 +674,7 @@ def getFormatFieldBraille(field, fieldCache, isAtStart, formatConfig):
 					if marker:
 						textList.append(marker)
 				except Exception:
-					log.debugWarning("BrailleExtender: getParagraphStartMarker failed", exc_info=True)
+					log.debugWarning("getParagraphStartMarker failed", exc_info=True)
 		if formatConfig["reportParagraphIndentation"] and use_be_format_field_chrome("paragraphIndentation"):
 			indentLabels = {
 				"left-indent": (N_("left indent"), N_("no left indent")),
@@ -717,7 +715,7 @@ def getFormatFieldBraille(field, fieldCache, isAtStart, formatConfig):
 			try:
 				textList.append(braille.positiveStateLabels[controlTypes.State.COLLAPSED])
 			except Exception:
-				log.debugWarning("BrailleExtender: collapsed state label failed", exc_info=True)
+				log.debugWarning("collapsed state label failed", exc_info=True)
 
 	if formatConfig["reportPage"] and use_be_format_field_chrome("page"):
 		pageNumber = field.get("page-number")
@@ -1504,7 +1502,7 @@ def _try_apply(name: str, apply_fn) -> bool:
 		_appliedPatches.add(name)
 		return True
 	except Exception as e:
-		log.warning("BrailleExtender: Could not apply patch %s: %s", name, e, exc_info=True)
+		log.warning("Could not apply patch %s: %s", name, e, exc_info=True)
 		return False
 
 
@@ -1588,13 +1586,27 @@ def apply_patches() -> None:
 
 	_patchesApplied = len(_appliedPatches) > 0
 	if not _patchesApplied:
-		log.error("BrailleExtender: No patches could be applied; add-on may not function correctly")
+		log.error("No patches could be applied; add-on may not function correctly")
 	else:
-		log.debug("BrailleExtender: Applied %d patch groups: %s", len(_appliedPatches), _appliedPatches)
-		try:
-			speechhistorymode.install()
-		except Exception:
-			log.warning("BrailleExtender: could not install speech history hooks", exc_info=True)
+		log.debug("Applied %d patch groups: %s", len(_appliedPatches), _appliedPatches)
+	_install_excel_braille_helpers()
+	try:
+		speechhistorymode.install()
+	except Exception:
+		log.warning("could not install speech history hooks", exc_info=True)
+
+
+def _install_excel_braille_helpers() -> None:
+	try:
+		from appModules.brailleExtenderExcel import (
+			install_excel_header_text_guards,
+			sync_excel_braille_regions_patch,
+		)
+
+		install_excel_header_text_guards()
+		sync_excel_braille_regions_patch()
+	except Exception:
+		log.warning("could not install Excel braille helpers", exc_info=True)
 
 
 def is_patch_applied(name: str) -> bool:
@@ -1623,6 +1635,16 @@ def unload_patches() -> None:
 	_appliedPatches.clear()
 
 	speechhistorymode.uninstall()
+	try:
+		from appModules.brailleExtenderExcel import (
+			uninstall_excel_braille_regions,
+			uninstall_excel_header_text_guards,
+		)
+
+		uninstall_excel_braille_regions()
+		uninstall_excel_header_text_guards()
+	except Exception:
+		pass
 
 	if "executeGesture" in applied:
 		try:
@@ -1651,7 +1673,7 @@ def unload_patches() -> None:
 				except AttributeError:
 					pass
 		except Exception as e:
-			log.warning("BrailleExtender: Error restoring braille_region patches: %s", e)
+			log.warning("Error restoring braille_region patches: %s", e)
 
 	if "braille_input" in applied:
 		try:
@@ -1660,13 +1682,13 @@ def unload_patches() -> None:
 			brailleInput.BrailleInputHandler.input = _originals["BrailleInputHandler.input"]
 			brailleInput.BrailleInputHandler.sendChars = _originals["BrailleInputHandler.sendChars"]
 		except Exception as e:
-			log.warning("BrailleExtender: Error restoring braille_input patches: %s", e)
+			log.warning("Error restoring braille_input patches: %s", e)
 
 	if "script_braille_routeTo" in applied:
 		try:
 			globalCommands.GlobalCommands.script_braille_routeTo = _originals["script_braille_routeTo"]
 		except Exception as e:
-			log.warning("BrailleExtender: Error restoring script_braille_routeTo: %s", e)
+			log.warning("Error restoring script_braille_routeTo: %s", e)
 
 	if "braille_handler" in applied:
 		try:
@@ -1694,12 +1716,12 @@ def unload_patches() -> None:
 				except AttributeError:
 					pass
 		except Exception as e:
-			log.warning("BrailleExtender: Error restoring braille_handler patches: %s", e)
+			log.warning("Error restoring braille_handler patches: %s", e)
 
 	if "louis_createTablesString" in applied and "_createTablesString" in _originals:
 		try:
 			louis._createTablesString = _originals["_createTablesString"]
 		except Exception as e:
-			log.warning("BrailleExtender: Error restoring louis patch: %s", e)
+			log.warning("Error restoring louis patch: %s", e)
 
-	log.info("BrailleExtender patches unloaded")
+	log.info("patches unloaded")

--- a/addon/globalPlugins/brailleExtender/settings.py
+++ b/addon/globalPlugins/brailleExtender/settings.py
@@ -30,6 +30,7 @@ from .common import (
 )
 from .autoscroll import SettingsDlg as AutoScrollDlg
 from .documentformatting import SettingsDlg as DocumentFormattingDlg
+from .excelSettings import SettingsDlg as ExcelDlg
 from .objectpresentation import SettingsDlg as ObjectPresentationDlg
 from .onehand import SettingsDlg as OneHandModeDlg
 from .rolelabels import SettingsDlg as RoleLabelsDlg
@@ -1244,6 +1245,7 @@ class AddonSettingsDialog(gui.settingsDialogs.MultiCategorySettingsDialog):
 		AutoScrollDlg,
 		SpeechHistorymodeDlg,
 		DocumentFormattingDlg,
+		ExcelDlg,
 		ObjectPresentationDlg,
 		BrailleTablesDlg,
 		UndefinedCharsDlg,

--- a/addon/globalPlugins/brailleExtender/speechhistorymode.py
+++ b/addon/globalPlugins/brailleExtender/speechhistorymode.py
@@ -174,7 +174,7 @@ def install() -> None:
 	braille.BrailleBuffer.scrollForward = scrollForward
 	braille.BrailleHandler.message = new_braille_message
 	_installed = True
-	log.debug("BrailleExtender: speech history mode patches installed")
+	log.debug("speech history mode patches installed")
 
 
 def uninstall() -> None:
@@ -194,10 +194,10 @@ def uninstall() -> None:
 		if _orig_braille_message is not None:
 			braille.BrailleHandler.message = _orig_braille_message
 	except Exception:
-		log.warning("BrailleExtender: error restoring speech history patches", exc_info=True)
+		log.warning("error restoring speech history patches", exc_info=True)
 	_orig_speak = _orig_scroll_back = _orig_scroll_forward = _orig_braille_message = None
 	_installed = False
-	log.debug("BrailleExtender: speech history mode patches uninstalled")
+	log.debug("speech history mode patches uninstalled")
 
 
 def is_installed() -> bool:

--- a/addon/globalPlugins/brailleExtender/utils.py
+++ b/addon/globalPlugins/brailleExtender/utils.py
@@ -383,6 +383,14 @@ def uncapitalize(text: str) -> str:
 def refresh_braille_for_current_focus() -> None:
 	"""Re-run braille focus handling for the document or foreground object (after display or config changes)."""
 	focus_object = api.getFocusObject()
+	if hasattr(focus_object, "excelCellInfo") or hasattr(focus_object, "excelCellObject"):
+		try:
+			from appModules.brailleExtenderExcel import refresh_excel_braille_display
+
+			refresh_excel_braille_display()
+			return
+		except Exception:
+			log.debugWarning("Excel braille refresh failed; using default refresh", exc_info=True)
 	tree_interceptor = focus_object.treeInterceptor
 	if tree_interceptor is not None:
 		updated_interceptor = treeInterceptorHandler.update(focus_object)


### PR DESCRIPTION
- Add a dedicated Excel settings category (moved from Document formatting) with
  formula reporting, scope, neighbor count, separator, and scope formula display
- Add brailleExtenderExcel app module: current-cell formulas in the description
  field; row/column overview lines with per-cell routing (edit current cell, jump
  to neighbors)
- Register the Excel app module override and install braille region / header
  guards from the global plugin
- Migrate legacy documentFormatting.cellFormula into excel.cellFormula on load
